### PR TITLE
Make only() work correctly with required properties

### DIFF
--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -291,6 +291,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
           properties: schema.properties.filter(p =>
             properties.includes(p.name)
           ),
+          required: schema.required.filter(p => properties.includes(p)),
         },
         ...options,
       })

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -833,6 +833,34 @@ describe('ObjectSchema', () => {
         type: 'object',
       })
     })
+
+    it('works correctly with required properties', () => {
+      const base = S.object()
+        .id('base')
+        .title('base')
+        .prop('foo', S.string().required())
+        .prop('bar', S.string())
+        .prop('baz', S.string().required())
+        .prop('qux', S.string())
+
+      const only = base.only(['foo', 'bar'])
+
+      expect(only.valueOf()).toEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'base',
+        title: 'base',
+        properties: {
+          foo: {
+            type: 'string',
+          },
+          bar: {
+            type: 'string',
+          },
+        },
+        required: ['foo'],
+        type: 'object',
+      })
+    })
   })
 
   describe('raw', () => {


### PR DESCRIPTION
Previously, if an object's properties were restricted with `.only([...])`, props that were removed were still required. (See the test I added for an example that was previously failing.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
