### PR TITLE
Fix test assertions

### DIFF
--- a/src/BaseSchema.test.js
+++ b/src/BaseSchema.test.js
@@ -354,7 +354,7 @@ describe('BaseSchema', () => {
         })
       })
 
-      it('S nested', () => {
+      it('S nested required', () => {
         expect(
           S.object()
             .prop('prop', S.anyOf([]).required())

--- a/src/FluentSchema.integration.test.js
+++ b/src/FluentSchema.integration.test.js
@@ -197,12 +197,12 @@ describe('S', () => {
       schema: S.object().prop('foo', S.string().enum(['foo'])),
     }
     const _config = require('lodash.merge')({}, config)
-    expect(config.schema[Symbol.for('fluent-schema-object')]).toBeDefined()
-    expect(_config.schema.isFluentJSONSchema).toBeTruthy()
-    expect(_config.schema[Symbol.for('fluent-schema-object')]).toBeUndefined()
     const schema = _config.schema.valueOf()
     const validate = ajv.compile(schema)
     it('matches', () => {
+      expect(config.schema[Symbol.for('fluent-schema-object')]).toBeDefined()
+      expect(_config.schema.isFluentJSONSchema).toBeTruthy()
+      expect(_config.schema[Symbol.for('fluent-schema-object')]).toBeUndefined()
       expect(schema).toEqual({
         $schema: 'http://json-schema.org/draft-07/schema#',
         type: 'object',

--- a/src/FluentSchema.integration.test.js
+++ b/src/FluentSchema.integration.test.js
@@ -574,9 +574,5 @@ describe('S', () => {
         })
       })
     })
-
-    describe('complex', () => {
-      it('works', () => {})
-    })
   })
 })

--- a/src/RawSchema.test.js
+++ b/src/RawSchema.test.js
@@ -253,29 +253,4 @@ describe('RawSchema', () => {
       })
     })
   })
-
-  /*  describe('constructor', () => {
-    it('without params', () => {
-      expect(RawSchema().valueOf()).toEqual({
-        // $schema: 'http://json-schema.org/draft-07/schema#',
-        type: 'object',
-      })
-    })
-
-  })
-
-  it('from S', () => {
-    expect(S.object().valueOf()).toEqual({
-      $schema: 'http://json-schema.org/draft-07/schema#',
-      type: 'object',
-    })
-  })
-
-  it('valueOf', () => {
-    expect(
-      ObjectSchema()
-        .prop('foo', S.string())
-        .valueOf()
-    ).toEqual({ properties: { foo: { type: 'string' } }, type: 'object' })
-  })*/
 })

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -3,7 +3,7 @@ const { StringSchema } = require('./StringSchema')
 const { ObjectSchema } = require('./ObjectSchema')
 
 describe('setRaw', () => {
-  it('add an attribute to a prop', () => {
+  it('add an attribute to a prop using ObjectSchema', () => {
     const factory = ObjectSchema
     const schema = setRaw(
       { schema: { properties: [{ name: 'foo', type: 'string' }] }, factory },
@@ -19,7 +19,7 @@ describe('setRaw', () => {
     })
   })
 
-  it('add an attribute to a prop', () => {
+  it('add an attribute to a prop using StringSchema', () => {
     const factory = StringSchema
     const schema = setRaw(
       { schema: { type: 'string', properties: [] }, factory },


### PR DESCRIPTION
Main purpose of this commit is to fix `expect` statements being outside of `it` blocks.
`expects` aren't executed outside of `it` or `test` blocks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
