### PR TITLE
chore(scripts): remove test paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,12 @@ jobs:
         uses: actions/setup-node@v2.1.4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: |
+      - name: Install Dependencies
+        run: |
           npm install --ignore-scripts
           npm run build --if-present
-          npm run test:coverage
+      - name: Tests
+        run: npm run test:coverage
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v1.1.2
         with:

--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
     ]
   },
   "scripts": {
-    "test": "jest src/*.test.js --verbose && npm run typescript",
+    "test": "jest --verbose && npm run typescript",
     "test:coverage": "jest --coverage && npm run typescript",
-    "test:watch": "jest src/*.test.js --verbose --watch",
+    "test:watch": "jest --verbose --watch",
     "typescript": "tsc --project ./src/types/tsconfig.json",
     "format": "prettier --write ./src/**/*.js",
-    "coverage": "jest src/**.test.js --coverage",
+    "coverage": "jest --coverage",
     "doc": "jsdoc2md ./src/*.js > docs/API.md"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,19 +52,19 @@
     ]
   },
   "scripts": {
+    "coverage": "jest --coverage",
+    "doc": "jsdoc2md ./src/*.js > docs/API.md",
+    "format": "prettier --write ./src/**/*.js",
     "test": "jest --verbose && npm run typescript",
     "test:coverage": "jest --coverage && npm run typescript",
     "test:watch": "jest --verbose --watch",
-    "typescript": "tsc --project ./src/types/tsconfig.json",
-    "format": "prettier --write ./src/**/*.js",
-    "coverage": "jest --coverage",
-    "doc": "jsdoc2md ./src/*.js > docs/API.md"
+    "typescript": "tsc --project ./src/types/tsconfig.json"
   },
   "devDependencies": {
     "ajv": "^6.10.2",
     "ajv-keywords": "^3.4.1",
     "husky": "^4.3.8",
-    "jest": "^24.3.1",
+    "jest": "^26.6.3",
     "jsdoc-to-markdown": "^6.0.1",
     "lint-staged": "^10.5.3",
     "lodash.merge": "^4.6.2",


### PR DESCRIPTION
Test paths are causing Jest to throw warnings.
The paths are already declared in `jest.collectCoverageFrom` in `package.json` so the paths inline with the script were redundant anyway. 😄 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
