### PR TITLE
fix: object schema extend extended schema

### DIFF
--- a/src/FluentJSONSchema.d.ts
+++ b/src/FluentJSONSchema.d.ts
@@ -122,7 +122,7 @@ export interface ObjectSchema extends BaseSchema<ObjectSchema> {
   patternProperties: (options: PatternPropertiesOptions) => ObjectSchema
   dependencies: (options: DependenciesOptions) => ObjectSchema
   propertyNames: (value: JSONSchema) => ObjectSchema
-  extend: (schema: ObjectSchema) => ExtendedSchema
+  extend: (schema: ObjectSchema | ExtendedSchema) => ExtendedSchema
   only: (properties: string[]) => ObjectSchema
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,18 +23,12 @@ const schema = S.object()
   .prop('email2', S.string().format(S.FORMATS.EMAIL))
   .prop(
     'avatar',
-    S.string()
-      .contentEncoding('base64')
-      .contentMediaType('image/png')
+    S.string().contentEncoding('base64').contentMediaType('image/png')
   )
   .required()
   .prop(
     'password',
-    S.string()
-      .default('123456')
-      .minLength(6)
-      .maxLength(12)
-      .pattern('.*')
+    S.string().default('123456').minLength(6).maxLength(12).pattern('.*')
   )
   .required()
   .prop('addresses', S.array().items([S.ref('#address')]))
@@ -89,8 +83,10 @@ try {
   }
 }
 
-const arrayExtendedSchema = S.array()
-  .items(userSchema)
-  .valueOf()
+const arrayExtendedSchema = S.array().items(userSchema).valueOf()
 
 console.log('array of user\n', JSON.stringify(arrayExtendedSchema))
+
+const extendExtendedSchema = S.object().extend(userSchema)
+
+console.log('extend of user\n', JSON.stringify(extendExtendedSchema))


### PR DESCRIPTION
Fix `ObjectSchema` cannot extend `ExtendedSchema` in TypeScript

Resolve: #108 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
