### PR TITLE
Fix: throw on root-level required

### DIFF
--- a/src/BaseSchema.js
+++ b/src/BaseSchema.js
@@ -195,8 +195,9 @@ const BaseSchema = (
       : currentProp
       ? [...schema.required, currentProp.name]
       : [REQUIRED]
+
     if(!isUniq(required)){
-      throw new FluentSchemaError("'required' has repeated keys, check your calls to require()")
+      throw new FluentSchemaError("'required' has repeated keys, check your calls to .required()")
     }
 
     return options.factory({
@@ -413,7 +414,7 @@ const BaseSchema = (
     const { properties, definitions, required, $schema, ...rest } = schema
 
     if (isRoot && required && !required.every((v) => typeof v === 'string')) {
-      throw new FluentSchemaError("'required' has called on root-level schema, check your calls to require()")
+      throw new FluentSchemaError("'required' has called on root-level schema, check your calls to .required()")
     }
 
     return Object.assign(

--- a/src/BaseSchema.js
+++ b/src/BaseSchema.js
@@ -195,7 +195,6 @@ const BaseSchema = (
       : currentProp
       ? [...schema.required, currentProp.name]
       : [REQUIRED]
-    
     if(!isUniq(required)){
       throw new FluentSchemaError("'required' has repeated keys, check your calls to require()")
     }
@@ -406,10 +405,17 @@ const BaseSchema = (
   /**
    * It returns all the schema values
    *
+   * @param {Object} [options] - Options
+   * @param {boolean} [options.isRoot = true] - Is a root level schema
    * @returns {object}
    */
-  valueOf: () => {
+  valueOf: ({ isRoot } = { isRoot: true }) => {
     const { properties, definitions, required, $schema, ...rest } = schema
+
+    if (isRoot && required && !required.every((v) => typeof v === 'string')) {
+      throw new FluentSchemaError("'required' has called on root-level schema, check your calls to require()")
+    }
+
     return Object.assign(
       $schema ? { $schema } : {},
       Object.keys(definitions || []).length > 0

--- a/src/BaseSchema.test.js
+++ b/src/BaseSchema.test.js
@@ -178,6 +178,16 @@ describe('BaseSchema', () => {
         })
       })
 
+      it('root-level required', () => {
+        expect(() => {
+          return S.object().required().valueOf()
+        }).toThrowError(
+          new S.FluentSchemaError(
+            "'required' has called on root-level schema, check your calls to require()"
+          )
+        )
+      })
+
       describe('array', () => {
         it('simple', () => {
           const required = ['foo', 'bar']

--- a/src/BaseSchema.test.js
+++ b/src/BaseSchema.test.js
@@ -161,7 +161,7 @@ describe('BaseSchema', () => {
             .prop("A", S.string()).required().required()
           }).toThrowError(
             new S.FluentSchemaError(
-              "'required' has repeated keys, check your calls to require()"
+              "'required' has repeated keys, check your calls to .required()"
             )
           )
         })
@@ -172,7 +172,7 @@ describe('BaseSchema', () => {
             .prop("A", S.string().required())
           }).toThrowError(
             new S.FluentSchemaError(
-              "'required' has repeated keys, check your calls to require()"
+              "'required' has repeated keys, check your calls to .required()"
             )
           )
         })
@@ -183,7 +183,7 @@ describe('BaseSchema', () => {
           return S.object().required().valueOf()
         }).toThrowError(
           new S.FluentSchemaError(
-            "'required' has called on root-level schema, check your calls to require()"
+            "'required' has called on root-level schema, check your calls to .required()"
           )
         )
       })

--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -58,7 +58,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
         ])
       }
       if (isFluentSchema(value)) {
-        const { $schema, ...rest } = value.valueOf()
+        const { $schema, ...rest } = value.valueOf({ isRoot: false })
         return setAttribute({ schema, ...options }, [
           'additionalProperties',
           { ...rest },
@@ -127,7 +127,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
           )
         return {
           ...memo,
-          [pattern]: omit(schema.valueOf(), ['$schema']),
+          [pattern]: omit(schema.valueOf({ isRoot: false }), ['$schema']),
         }
       }, {})
       return setAttribute({ schema, ...options }, [
@@ -158,7 +158,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
           ...memo,
           [prop]: Array.isArray(schema)
             ? schema
-            : omit(schema.valueOf(), ['$schema', 'type', 'definitions']),
+            : omit(schema.valueOf({ isRoot: false }), ['$schema', 'type', 'definitions']),
         }
       }, {})
       return setAttribute({ schema, ...options }, [
@@ -182,7 +182,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
         throw new FluentSchemaError("'propertyNames' must be a S")
       return setAttribute({ schema, ...options }, [
         'propertyNames',
-        omit(value.valueOf(), ['$schema']),
+        omit(value.valueOf({ isRoot: false }), ['$schema']),
         'object',
       ])
     },
@@ -204,7 +204,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
           )}'. Pass a FluentSchema object`
         )
       const target = props.def ? 'definitions' : 'properties'
-      let attributes = props.valueOf()
+      let attributes = props.valueOf({ isRoot: false })
       const $id =
         attributes.$id ||
         (options.generateIds ? `#${target}/${name}` : undefined)
@@ -310,7 +310,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
     // TODO LS Is a definition a proper schema?
     definition: (name, props = {}) =>
       ObjectSchema({ schema, ...options }).prop(name, {
-        ...props.valueOf(),
+        ...props.valueOf({ isRoot: false }),
         def: true,
       }),
   }

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -21,18 +21,12 @@ const schema = S.object()
   .prop('email', S.string().format('email'))
   .prop(
     'avatar',
-    S.string()
-      .contentEncoding('base64')
-      .contentMediaType('image/png')
+    S.string().contentEncoding('base64').contentMediaType('image/png')
   )
   .required()
   .prop(
     'password',
-    S.string()
-      .default('123456')
-      .minLength(6)
-      .maxLength(12)
-      .pattern('.*')
+    S.string().default('123456').minLength(6).maxLength(12).pattern('.*')
   )
   .required()
   .prop('addresses', S.array().items([S.ref('#address')]))

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -21,12 +21,18 @@ const schema = S.object()
   .prop('email', S.string().format('email'))
   .prop(
     'avatar',
-    S.string().contentEncoding('base64').contentMediaType('image/png')
+    S.string()
+      .contentEncoding('base64')
+      .contentMediaType('image/png')
   )
   .required()
   .prop(
     'password',
-    S.string().default('123456').minLength(6).maxLength(12).pattern('.*')
+    S.string()
+      .default('123456')
+      .minLength(6)
+      .maxLength(12)
+      .pattern('.*')
   )
   .required()
   .prop('addresses', S.array().items([S.ref('#address')]))

--- a/src/utils.js
+++ b/src/utils.js
@@ -158,7 +158,7 @@ const appendRequired = ({
 
   const patchedRequired = [...schema.required, ...schemaRequired];
   if(!isUniq(patchedRequired)){
-    throw new FluentSchemaError("'required' has repeated keys, check your calls to require()")
+    throw new FluentSchemaError("'required' has repeated keys, check your calls to .required()")
   }
 
   const schemaPatched = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -205,7 +205,7 @@ const setComposeType = ({ prop, schemas, schema, options }) => {
   }
 
   const values = schemas.map(schema => {
-    const { $schema, ...props } = schema.valueOf()
+    const { $schema, ...props } = schema.valueOf({ isRoot: false })
     return props
   })
 


### PR DESCRIPTION
Fixes #132
I added `isRoot` option for `valueOf` method, which is true by default and false for internal calls.
I didn't update `.d.ts` files, should I do? 
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
