### PR TITLE
fix: raw key Typescript return type

### DIFF
--- a/src/FluentJSONSchema.d.ts
+++ b/src/FluentJSONSchema.d.ts
@@ -22,7 +22,7 @@ export interface BaseSchema<T> {
   writeOnly: (isWriteOnly?: boolean) => T
   isFluentSchema: boolean
   isFluentJSONSchema: boolean
-  raw: (fragment: any) => JSONSchema
+  raw: (fragment: any) => T
 }
 
 export type TYPE =
@@ -239,7 +239,7 @@ export interface S extends BaseSchema<S> {
   >(
     types: T
   ) => MixedSchema<T>
-  raw: (fragment: any) => JSONSchema
+  raw: (fragment: any) => S
   FORMATS: FORMATS
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,3 +90,11 @@ console.log('array of user\n', JSON.stringify(arrayExtendedSchema))
 const extendExtendedSchema = S.object().extend(userSchema)
 
 console.log('extend of user\n', JSON.stringify(extendExtendedSchema))
+
+const rawNullableSchema = S.object()
+  .raw({ nullable: true })
+  .required(['foo', 'hello'])
+  .prop('foo', S.string())
+  .prop('hello', S.string())
+
+console.log('raw schema with nullable props\n', JSON.stringify(rawNullableSchema))


### PR DESCRIPTION
Fixes the `raw` return on Typescript types

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included (not sure if the `index.ts` is considered a benchmark)
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Related issue: https://github.com/fastify/fluent-json-schema/issues/129