### PR TITLE
Adds support to dependentRequired and dependentSchemas

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -124,11 +124,13 @@ then validation succeeds against this keyword if the instance successfully valid
 it can be handy to arbitrary modify the schema injecting a fragment</p>
 <ul>
 <li>Examples:</li>
+</ul>
+<ul>
 <li>S.number().raw({ nullable:true })</li>
 <li>S.string().format(&#39;date&#39;).raw({ formatMaximum: &#39;2020-01-01&#39; })</li>
 </ul>
 </dd>
-<dt><a href="#valueOf">valueOf()</a> ⇒ <code><a href="#object">object</a></code></dt>
+<dt><a href="#valueOf">valueOf([options])</a> ⇒ <code><a href="#object">object</a></code></dt>
 <dd><p>It returns all the schema values</p>
 </dd>
 <dt><a href="#BooleanSchema">BooleanSchema([options])</a> ⇒ <code><a href="#StringSchema">StringSchema</a></code></dt>
@@ -173,6 +175,8 @@ it can be handy to arbitrary modify the schema injecting a fragment</p>
 it can be handy to arbitrary modify the schema injecting a fragment</p>
 <ul>
 <li>Examples:</li>
+</ul>
+<ul>
 <li>S.raw({ nullable:true, format: &#39;date&#39;, formatMaximum: &#39;2020-01-01&#39; })</li>
 <li>S.string().format(&#39;date&#39;).raw({ formatMaximum: &#39;2020-01-01&#39; })</li>
 </ul>
@@ -247,6 +251,16 @@ If the dependency value is a subschema, and the dependency key is a property in 
 If the dependency value is an array, each element in the array, if any, MUST be a string, and MUST be unique. If the dependency key is a property in the instance, each of the items in the dependency value must be a property that exists in the instance.</p>
 <p><a href="https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.5.7">reference</a></p>
 </dd>
+<dt><a href="#dependentRequired">dependentRequired(opts)</a> ⇒ <code>FluentSchema</code></dt>
+<dd><p>The value of &quot;properties&quot; MUST be an object. Each dependency value MUST be an array.
+Each element in the array MUST be a string and MUST be unique. If the dependency key is a property in the instance, each of the items in the dependency value must be a property that exists in the instance.</p>
+<p><a href="https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.5.4">reference</a></p>
+</dd>
+<dt><a href="#dependentSchemas">dependentSchemas(opts)</a> ⇒ <code>FluentSchema</code></dt>
+<dd><p>The value of &quot;properties&quot; MUST be an object. The dependency value MUST be a valid JSON Schema.
+Each dependency key is a property in the instance and the entire instance must validate against the dependency value.</p>
+<p><a href="https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.2.2.4">reference</a></p>
+</dd>
 <dt><a href="#propertyNames">propertyNames(value)</a> ⇒ <code>FluentSchema</code></dt>
 <dd><p>If the instance is an object, this keyword validates if every property name in the instance validates against the provided schema.
 Note the property name that the schema is testing will always be a string.</p>
@@ -255,6 +269,9 @@ Note the property name that the schema is testing will always be a string.</p>
 <dt><a href="#prop">prop(name, props)</a> ⇒ <code>FluentSchema</code></dt>
 <dd><p>The value of &quot;properties&quot; MUST be an object. Each value of this object MUST be a valid JSON Schema.</p>
 <p><a href="https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.5.4">reference</a></p>
+</dd>
+<dt><a href="#only">only(properties)</a> ⇒ <code><a href="#ObjectSchema">ObjectSchema</a></code></dt>
+<dd><p>Returns an object schema with only a subset of keys provided</p>
 </dd>
 <dt><a href="#definition">definition(name, props)</a> ⇒ <code>FluentSchema</code></dt>
 <dd><p>The &quot;definitions&quot; keywords provides a standardized location for schema authors to inline re-usable JSON Schemas into a more general schema.
@@ -302,21 +319,19 @@ The length of a string instance is defined as the number of its characters as de
 <a name="ArraySchema"></a>
 
 ## ArraySchema([options]) ⇒ [<code>ArraySchema</code>](#ArraySchema)
-
 Represents a ArraySchema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param                 | Type                                       | Default            | Description                                        |
-| --------------------- | ------------------------------------------ | ------------------ | -------------------------------------------------- |
-| [options]             | <code>Object</code>                        |                    | Options                                            |
-| [options.schema]      | [<code>StringSchema</code>](#StringSchema) |                    | Default schema                                     |
-| [options.generateIds] | [<code>boolean</code>](#boolean)           | <code>false</code> | generate the id automatically e.g. #properties.foo |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.schema] | [<code>StringSchema</code>](#StringSchema) |  | Default schema |
+| [options.generateIds] | [<code>boolean</code>](#boolean) | <code>false</code> | generate the id automatically e.g. #properties.foo |
 
 <a name="items"></a>
 
 ## items(items) ⇒ <code>FluentSchema</code>
-
 This keyword determines how child instances validate for arrays, and does not directly validate the immediate instance itself.
 If "items" is a schema, validation succeeds if all elements in the array successfully validate against that schema.
 If "items" is an array of schemas, validation succeeds if each element of the instance validates against the schema at the same position, if any.
@@ -324,250 +339,232 @@ Omitting this keyword has the same behavior as an empty schema.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.4.1)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                                                                 |
-| ----- | -------------------------------------------------------------------- |
-| items | <code>FluentSchema</code> \| <code>Array.&lt;FluentSchema&gt;</code> |
+| Param | Type |
+| --- | --- |
+| items | <code>FluentSchema</code> \| <code>Array.&lt;FluentSchema&gt;</code> | 
 
 <a name="additionalItems"></a>
 
 ## additionalItems(items) ⇒ <code>FluentSchema</code>
-
 This keyword determines how child instances validate for arrays, and does not directly validate the immediate instance itself.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.4.2)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                                                          |
-| ----- | ------------------------------------------------------------- |
-| items | <code>FluentSchema</code> \| [<code>boolean</code>](#boolean) |
+| Param | Type |
+| --- | --- |
+| items | <code>FluentSchema</code> \| [<code>boolean</code>](#boolean) | 
 
 <a name="contains"></a>
 
 ## contains(value) ⇒ <code>FluentSchema</code>
-
 An array instance is valid against "contains" if at least one of its elements is valid against the given schema.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.4.6)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                      |
-| ----- | ------------------------- |
-| value | <code>FluentSchema</code> |
+| Param | Type |
+| --- | --- |
+| value | <code>FluentSchema</code> | 
 
 <a name="uniqueItems"></a>
 
 ## uniqueItems(boolean) ⇒ <code>FluentSchema</code>
-
 If this keyword has boolean value false, the instance validates successfully.
 If it has boolean value true, the instance validates successfully if all of its elements are unique.
 Omitting this keyword has the same behavior as a value of false.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.4.5)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param   | Type                             |
-| ------- | -------------------------------- |
-| boolean | [<code>boolean</code>](#boolean) |
+| Param | Type |
+| --- | --- |
+| boolean | [<code>boolean</code>](#boolean) | 
 
 <a name="minItems"></a>
 
 ## minItems(min) ⇒ <code>FluentSchema</code>
-
 An array instance is valid against "minItems" if its size is greater than, or equal to, the value of this keyword.
 Omitting this keyword has the same behavior as a value of 0.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.4.4)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| min   | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| min | [<code>number</code>](#number) | 
 
 <a name="maxItems"></a>
 
 ## maxItems(max) ⇒ <code>FluentSchema</code>
-
 An array instance is valid against "minItems" if its size is greater than, or equal to, the value of this keyword.
 Omitting this keyword has the same behavior as a value of 0.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.4.3)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| max   | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| max | [<code>number</code>](#number) | 
 
 <a name="BaseSchema"></a>
 
 ## BaseSchema([options]) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 Represents a BaseSchema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param                 | Type                                   | Default            | Description                                        |
-| --------------------- | -------------------------------------- | ------------------ | -------------------------------------------------- |
-| [options]             | <code>Object</code>                    |                    | Options                                            |
-| [options.schema]      | [<code>BaseSchema</code>](#BaseSchema) |                    | Default schema                                     |
-| [options.generateIds] | [<code>boolean</code>](#boolean)       | <code>false</code> | generate the id automatically e.g. #properties.foo |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.schema] | [<code>BaseSchema</code>](#BaseSchema) |  | Default schema |
+| [options.generateIds] | [<code>boolean</code>](#boolean) | <code>false</code> | generate the id automatically e.g. #properties.foo |
 
 <a name="id"></a>
 
 ## id(id) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 It defines a URI for the schema, and the base URI that other URI references within the schema are resolved against.
 
 [reference](https://tools.ietf.org/html/draft-handrews-json-schema-01#section-8.2)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           | Description |
-| ----- | ------------------------------ | ----------- |
-| id    | [<code>string</code>](#string) | an #id      |
+| Param | Type | Description |
+| --- | --- | --- |
+| id | [<code>string</code>](#string) | an #id |
 
 <a name="title"></a>
 
 ## title(title) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 It can be used to decorate a user interface with information about the data produced by this user interface. A title will preferably be short.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.10.1)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| title | [<code>string</code>](#string) |
+| Param | Type |
+| --- | --- |
+| title | [<code>string</code>](#string) | 
 
 <a name="description"></a>
 
 ## description(description) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 It can be used to decorate a user interface with information about the data
 produced by this user interface. A description provides explanation about
 the purpose of the instance described by the schema.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.10.1)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param       | Type                           |
-| ----------- | ------------------------------ |
-| description | [<code>string</code>](#string) |
+| Param | Type |
+| --- | --- |
+| description | [<code>string</code>](#string) | 
 
 <a name="examples"></a>
 
 ## examples(examples) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 The value of this keyword MUST be an array.
 There are no restrictions placed on the values within the array.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.10.4)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param    | Type                           |
-| -------- | ------------------------------ |
-| examples | [<code>string</code>](#string) |
+| Param | Type |
+| --- | --- |
+| examples | [<code>string</code>](#string) | 
 
 <a name="ref"></a>
 
 ## ref(ref) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 The value must be a valid id e.g. #properties/foo
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| ref   | [<code>string</code>](#string) |
+| Param | Type |
+| --- | --- |
+| ref | [<code>string</code>](#string) | 
 
 <a name="enum"></a>
 
 ## enum(values) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 The value of this keyword MUST be an array. This array SHOULD have at least one element. Elements in the array SHOULD be unique.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.1.2)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param  | Type                         |
-| ------ | ---------------------------- |
-| values | [<code>array</code>](#array) |
+| Param | Type |
+| --- | --- |
+| values | [<code>array</code>](#array) | 
 
 <a name="const"></a>
 
 ## const(value) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 The value of this keyword MAY be of any type, including null.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.1.3)
 
-**Kind**: global function
+**Kind**: global function  
 
 | Param |
-| ----- |
-| value |
+| --- |
+| value | 
 
 <a name="default"></a>
 
 ## default(defaults) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 There are no restrictions placed on the value of this keyword.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.10.2)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param    |
-| -------- |
-| defaults |
+| Param |
+| --- |
+| defaults | 
 
 <a name="readOnly"></a>
 
 ## readOnly(isReadOnly) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 The value of readOnly can be left empty to indicate the property is readOnly.
 It takes an optional boolean which can be used to explicitly set readOnly true/false.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.10.3)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param      | Type                                                       |
-| ---------- | ---------------------------------------------------------- |
-| isReadOnly | [<code>boolean</code>](#boolean) \| <code>undefined</code> |
+| Param | Type |
+| --- | --- |
+| isReadOnly | [<code>boolean</code>](#boolean) \| <code>undefined</code> | 
 
 <a name="writeOnly"></a>
 
 ## writeOnly(isWriteOnly) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 The value of writeOnly can be left empty to indicate the property is writeOnly.
 It takes an optional boolean which can be used to explicitly set writeOnly true/false.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.10.3)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param       | Type                                                       |
-| ----------- | ---------------------------------------------------------- |
-| isWriteOnly | [<code>boolean</code>](#boolean) \| <code>undefined</code> |
+| Param | Type |
+| --- | --- |
+| isWriteOnly | [<code>boolean</code>](#boolean) \| <code>undefined</code> | 
 
 <a name="required"></a>
 
 ## required() ⇒ <code>FluentSchema</code>
-
 Required has to be chained to a property:
 Examples:
-
 - S.prop('prop').required()
 - S.prop('prop', S.number()).required()
 - S.required(['foo', 'bar'])
@@ -578,148 +575,142 @@ Examples:
 <a name="not"></a>
 
 ## not(not) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 This keyword's value MUST be a valid JSON Schema.
 An instance is valid against this keyword if it fails to validate successfully against the schema defined by this keyword.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.7.4)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                      |
-| ----- | ------------------------- |
-| not   | <code>FluentSchema</code> |
+| Param | Type |
+| --- | --- |
+| not | <code>FluentSchema</code> | 
 
 <a name="anyOf"></a>
 
 ## anyOf(schemas) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 It MUST be a non-empty array. Each item of the array MUST be a valid JSON Schema.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.7.2)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param   | Type                         |
-| ------- | ---------------------------- |
-| schemas | [<code>array</code>](#array) |
+| Param | Type |
+| --- | --- |
+| schemas | [<code>array</code>](#array) | 
 
 <a name="allOf"></a>
 
 ## allOf(schemas) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 It MUST be a non-empty array. Each item of the array MUST be a valid JSON Schema.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.7.1)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param   | Type                         |
-| ------- | ---------------------------- |
-| schemas | [<code>array</code>](#array) |
+| Param | Type |
+| --- | --- |
+| schemas | [<code>array</code>](#array) | 
 
 <a name="oneOf"></a>
 
 ## oneOf(schemas) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 It MUST be a non-empty array. Each item of the array MUST be a valid JSON Schema.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.7.3)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param   | Type                         |
-| ------- | ---------------------------- |
-| schemas | [<code>array</code>](#array) |
+| Param | Type |
+| --- | --- |
+| schemas | [<code>array</code>](#array) | 
 
 <a name="ifThen"></a>
 
 ## ifThen(ifClause, thenClause) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 This validation outcome of this keyword's subschema has no direct effect on the overall validation result.
 Rather, it controls which of the "then" or "else" keywords are evaluated.
 When "if" is present, and the instance successfully validates against its subschema, then
 validation succeeds against this keyword if the instance also successfully validates against this keyword's subschema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param      | Type                                   | Description                                                                                            |
-| ---------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| ifClause   | [<code>BaseSchema</code>](#BaseSchema) | [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.6.1) |
+| Param | Type | Description |
+| --- | --- | --- |
+| ifClause | [<code>BaseSchema</code>](#BaseSchema) | [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.6.1) |
 | thenClause | [<code>BaseSchema</code>](#BaseSchema) | [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.6.2) |
 
 <a name="ifThenElse"></a>
 
 ## ifThenElse(ifClause, thenClause, elseClause) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 When "if" is present, and the instance fails to validate against its subschema,
 then validation succeeds against this keyword if the instance successfully validates against this keyword's subschema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param      | Type                                   | Description                                                                                            |
-| ---------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| ifClause   | [<code>BaseSchema</code>](#BaseSchema) | [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.6.1) |
+| Param | Type | Description |
+| --- | --- | --- |
+| ifClause | [<code>BaseSchema</code>](#BaseSchema) | [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.6.1) |
 | thenClause | [<code>BaseSchema</code>](#BaseSchema) | [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.6.2) |
 | elseClause | [<code>BaseSchema</code>](#BaseSchema) | [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.6.3) |
 
 <a name="raw"></a>
 
 ## raw(fragment) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 Because the differences between JSON Schemas and Open API (Swagger)
 it can be handy to arbitrary modify the schema injecting a fragment
 
-- Examples:
+* Examples:
+- S.number().raw({ nullable:true })
+- S.string().format('date').raw({ formatMaximum: '2020-01-01' })
 
-* S.number().raw({ nullable:true })
-* S.string().format('date').raw({ formatMaximum: '2020-01-01' })
+**Kind**: global function  
 
-**Kind**: global function
-
-| Param    | Type                           | Description                                                                                                                               |
-| -------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Param | Type | Description |
+| --- | --- | --- |
 | fragment | [<code>string</code>](#string) | an arbitrary JSON Schema to inject [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.3.3) |
 
 <a name="valueOf"></a>
 
-## valueOf() ⇒ [<code>object</code>](#object)
-
+## valueOf([options]) ⇒ [<code>object</code>](#object)
 It returns all the schema values
 
 **Kind**: global function  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.isRoot] | [<code>boolean</code>](#boolean) | <code>true</code> | Is a root level schema |
+
 <a name="BooleanSchema"></a>
 
 ## BooleanSchema([options]) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 Represents a BooleanSchema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param                 | Type                                       | Default            | Description                                        |
-| --------------------- | ------------------------------------------ | ------------------ | -------------------------------------------------- |
-| [options]             | <code>Object</code>                        |                    | Options                                            |
-| [options.schema]      | [<code>StringSchema</code>](#StringSchema) |                    | Default schema                                     |
-| [options.generateIds] | [<code>boolean</code>](#boolean)           | <code>false</code> | generate the id automatically e.g. #properties.foo |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.schema] | [<code>StringSchema</code>](#StringSchema) |  | Default schema |
+| [options.generateIds] | [<code>boolean</code>](#boolean) | <code>false</code> | generate the id automatically e.g. #properties.foo |
 
 <a name="S"></a>
 
 ## S([options]) ⇒ [<code>S</code>](#S)
-
 Represents a S.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param                 | Type                             | Default            | Description                                        |
-| --------------------- | -------------------------------- | ------------------ | -------------------------------------------------- |
-| [options]             | <code>Object</code>              |                    | Options                                            |
-| [options.schema]      | [<code>S</code>](#S)             |                    | Default schema                                     |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.schema] | [<code>S</code>](#S) |  | Default schema |
 | [options.generateIds] | [<code>boolean</code>](#boolean) | <code>false</code> | generate the id automatically e.g. #properties.foo |
 
 <a name="string"></a>
 
 ## string() ⇒ [<code>StringSchema</code>](#StringSchema)
-
 Set a property to type string
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.3)
@@ -728,7 +719,6 @@ Set a property to type string
 <a name="number"></a>
 
 ## number() ⇒ [<code>NumberSchema</code>](#NumberSchema)
-
 Set a property to type number
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#numeric)
@@ -737,7 +727,6 @@ Set a property to type number
 <a name="integer"></a>
 
 ## integer() ⇒ [<code>IntegerSchema</code>](#IntegerSchema)
-
 Set a property to type integer
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#numeric)
@@ -746,7 +735,6 @@ Set a property to type integer
 <a name="boolean"></a>
 
 ## boolean() ⇒ [<code>BooleanSchema</code>](#BooleanSchema)
-
 Set a property to type boolean
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.7)
@@ -755,7 +743,6 @@ Set a property to type boolean
 <a name="array"></a>
 
 ## array() ⇒ [<code>ArraySchema</code>](#ArraySchema)
-
 Set a property to type array
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.4)
@@ -764,7 +751,6 @@ Set a property to type array
 <a name="object"></a>
 
 ## object() ⇒ [<code>ObjectSchema</code>](#ObjectSchema)
-
 Set a property to type object
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.5)
@@ -773,7 +759,6 @@ Set a property to type object
 <a name="null"></a>
 
 ## null() ⇒ [<code>NullSchema</code>](#NullSchema)
-
 Set a property to type null
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#general)
@@ -782,79 +767,72 @@ Set a property to type null
 <a name="mixed"></a>
 
 ## mixed(types) ⇒ [<code>MixedSchema</code>](#MixedSchema)
-
 A mixed schema is the union of multiple types (e.g. ['string', 'integer']
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                                                         |
-| ----- | ------------------------------------------------------------ |
-| types | [<code>[ &#x27;Array&#x27; ].&lt;string&gt;</code>](#string) |
+| Param | Type |
+| --- | --- |
+| types | [<code>Array.&lt;string&gt;</code>](#string) | 
 
 <a name="raw"></a>
 
 ## raw(fragment) ⇒ [<code>BaseSchema</code>](#BaseSchema)
-
 Because the differences between JSON Schemas and Open API (Swagger)
 it can be handy to arbitrary modify the schema injecting a fragment
 
-- Examples:
+* Examples:
+- S.raw({ nullable:true, format: 'date', formatMaximum: '2020-01-01' })
+- S.string().format('date').raw({ formatMaximum: '2020-01-01' })
 
-* S.raw({ nullable:true, format: 'date', formatMaximum: '2020-01-01' })
-* S.string().format('date').raw({ formatMaximum: '2020-01-01' })
+**Kind**: global function  
 
-**Kind**: global function
-
-| Param    | Type                           | Description                        |
-| -------- | ------------------------------ | ---------------------------------- |
+| Param | Type | Description |
+| --- | --- | --- |
 | fragment | [<code>string</code>](#string) | an arbitrary JSON Schema to inject |
 
 <a name="IntegerSchema"></a>
 
 ## IntegerSchema([options]) ⇒ [<code>NumberSchema</code>](#NumberSchema)
-
 Represents a NumberSchema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param                 | Type                                       | Default            | Description                                        |
-| --------------------- | ------------------------------------------ | ------------------ | -------------------------------------------------- |
-| [options]             | <code>Object</code>                        |                    | Options                                            |
-| [options.schema]      | [<code>NumberSchema</code>](#NumberSchema) |                    | Default schema                                     |
-| [options.generateIds] | [<code>boolean</code>](#boolean)           | <code>false</code> | generate the id automatically e.g. #properties.foo |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.schema] | [<code>NumberSchema</code>](#NumberSchema) |  | Default schema |
+| [options.generateIds] | [<code>boolean</code>](#boolean) | <code>false</code> | generate the id automatically e.g. #properties.foo |
 
 <a name="MixedSchema"></a>
 
 ## MixedSchema([options]) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 Represents a MixedSchema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param                 | Type                                     | Default            | Description                                        |
-| --------------------- | ---------------------------------------- | ------------------ | -------------------------------------------------- |
-| [options]             | <code>Object</code>                      |                    | Options                                            |
-| [options.schema]      | [<code>MixedSchema</code>](#MixedSchema) |                    | Default schema                                     |
-| [options.generateIds] | [<code>boolean</code>](#boolean)         | <code>false</code> | generate the id automatically e.g. #properties.foo |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.schema] | [<code>MixedSchema</code>](#MixedSchema) |  | Default schema |
+| [options.generateIds] | [<code>boolean</code>](#boolean) | <code>false</code> | generate the id automatically e.g. #properties.foo |
 
 <a name="NullSchema"></a>
 
 ## NullSchema([options]) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 Represents a NullSchema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param                 | Type                                       | Default            | Description                                        |
-| --------------------- | ------------------------------------------ | ------------------ | -------------------------------------------------- |
-| [options]             | <code>Object</code>                        |                    | Options                                            |
-| [options.schema]      | [<code>StringSchema</code>](#StringSchema) |                    | Default schema                                     |
-| [options.generateIds] | [<code>boolean</code>](#boolean)           | <code>false</code> | generate the id automatically e.g. #properties.foo |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.schema] | [<code>StringSchema</code>](#StringSchema) |  | Default schema |
+| [options.generateIds] | [<code>boolean</code>](#boolean) | <code>false</code> | generate the id automatically e.g. #properties.foo |
 
 <a name="null"></a>
 
 ## null() ⇒ <code>FluentSchema</code>
-
 Set a property to type null
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.1.1)
@@ -863,105 +841,97 @@ Set a property to type null
 <a name="NumberSchema"></a>
 
 ## NumberSchema([options]) ⇒ [<code>NumberSchema</code>](#NumberSchema)
-
 Represents a NumberSchema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param                 | Type                                       | Default            | Description                                        |
-| --------------------- | ------------------------------------------ | ------------------ | -------------------------------------------------- |
-| [options]             | <code>Object</code>                        |                    | Options                                            |
-| [options.schema]      | [<code>NumberSchema</code>](#NumberSchema) |                    | Default schema                                     |
-| [options.generateIds] | [<code>boolean</code>](#boolean)           | <code>false</code> | generate the id automatically e.g. #properties.foo |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.schema] | [<code>NumberSchema</code>](#NumberSchema) |  | Default schema |
+| [options.generateIds] | [<code>boolean</code>](#boolean) | <code>false</code> | generate the id automatically e.g. #properties.foo |
 
 <a name="minimum"></a>
 
 ## minimum(min) ⇒ <code>FluentSchema</code>
-
-It represents an inclusive lower limit for a numeric instance.
+It represents  an inclusive lower limit for a numeric instance.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.2.4)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| min   | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| min | [<code>number</code>](#number) | 
 
 <a name="exclusiveMinimum"></a>
 
 ## exclusiveMinimum(min) ⇒ <code>FluentSchema</code>
-
 It represents an exclusive lower limit for a numeric instance.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.2.5)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| min   | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| min | [<code>number</code>](#number) | 
 
 <a name="maximum"></a>
 
 ## maximum(max) ⇒ <code>FluentSchema</code>
-
-It represents an inclusive upper limit for a numeric instance.
+It represents  an inclusive upper limit for a numeric instance.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.2.2)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| max   | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| max | [<code>number</code>](#number) | 
 
 <a name="exclusiveMaximum"></a>
 
 ## exclusiveMaximum(max) ⇒ <code>FluentSchema</code>
-
 It represents an exclusive upper limit for a numeric instance.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.2.3)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| max   | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| max | [<code>number</code>](#number) | 
 
 <a name="multipleOf"></a>
 
 ## multipleOf(multiple) ⇒ <code>FluentSchema</code>
-
 It's strictly greater than 0.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.2.1)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param    | Type                           |
-| -------- | ------------------------------ |
-| multiple | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| multiple | [<code>number</code>](#number) | 
 
 <a name="ObjectSchema"></a>
 
 ## ObjectSchema([options]) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 Represents a ObjectSchema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param                 | Type                                       | Default            | Description                                        |
-| --------------------- | ------------------------------------------ | ------------------ | -------------------------------------------------- |
-| [options]             | <code>Object</code>                        |                    | Options                                            |
-| [options.schema]      | [<code>StringSchema</code>](#StringSchema) |                    | Default schema                                     |
-| [options.generateIds] | [<code>boolean</code>](#boolean)           | <code>false</code> | generate the id automatically e.g. #properties.foo |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.schema] | [<code>StringSchema</code>](#StringSchema) |  | Default schema |
+| [options.generateIds] | [<code>boolean</code>](#boolean) | <code>false</code> | generate the id automatically e.g. #properties.foo |
 
 <a name="additionalProperties"></a>
 
 ## additionalProperties(value) ⇒ <code>FluentSchema</code>
-
 This keyword determines how child instances validate for objects, and does not directly validate the immediate instance itself.
 Validation with "additionalProperties" applies only to the child values of instance names that do not match any names in "properties",
 and do not match any regular expression in "patternProperties".
@@ -970,44 +940,41 @@ Omitting this keyword has the same behavior as an empty schema.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.5.6)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                                                          |
-| ----- | ------------------------------------------------------------- |
-| value | <code>FluentSchema</code> \| [<code>boolean</code>](#boolean) |
+| Param | Type |
+| --- | --- |
+| value | <code>FluentSchema</code> \| [<code>boolean</code>](#boolean) | 
 
 <a name="maxProperties"></a>
 
 ## maxProperties(max) ⇒ <code>FluentSchema</code>
-
 An object instance is valid against "maxProperties" if its number of properties is less than, or equal to, the value of this keyword.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.5.1)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| max   | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| max | [<code>number</code>](#number) | 
 
 <a name="minProperties"></a>
 
 ## minProperties(min) ⇒ <code>FluentSchema</code>
-
 An object instance is valid against "minProperties" if its number of properties is greater than, or equal to, the value of this keyword.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.5.2)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| min   | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| min | [<code>number</code>](#number) | 
 
 <a name="patternProperties"></a>
 
 ## patternProperties(opts) ⇒ <code>FluentSchema</code>
-
 Each property name of this object SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect.
 Each property value of this object MUST be a valid JSON Schema.
 This keyword determines how child instances validate for objects, and does not directly validate the immediate instance itself.
@@ -1016,16 +983,15 @@ Validation succeeds if, for each instance name that matches any regular expressi
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.5.5)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| opts  | [<code>object</code>](#object) |
+| Param | Type |
+| --- | --- |
+| opts | [<code>object</code>](#object) | 
 
 <a name="dependencies"></a>
 
 ## dependencies(opts) ⇒ <code>FluentSchema</code>
-
 This keyword specifies rules that are evaluated if the instance is an object and contains a certain property.
 This keyword's value MUST be an object. Each property specifies a dependency. Each dependency value MUST be an array or a valid JSON Schema.
 If the dependency value is a subschema, and the dependency key is a property in the instance, the entire instance must validate against the dependency value.
@@ -1033,170 +999,199 @@ If the dependency value is an array, each element in the array, if any, MUST be 
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.5.7)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| opts  | [<code>object</code>](#object) |
+| Param | Type |
+| --- | --- |
+| opts | [<code>object</code>](#object) | 
+
+<a name="dependentRequired"></a>
+
+## dependentRequired(opts) ⇒ <code>FluentSchema</code>
+The value of "properties" MUST be an object. Each dependency value MUST be an array.
+Each element in the array MUST be a string and MUST be unique. If the dependency key is a property in the instance, each of the items in the dependency value must be a property that exists in the instance.
+
+[reference](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.5.4)
+
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| opts | [<code>object</code>](#object) | 
+
+<a name="dependentSchemas"></a>
+
+## dependentSchemas(opts) ⇒ <code>FluentSchema</code>
+The value of "properties" MUST be an object. The dependency value MUST be a valid JSON Schema.
+Each dependency key is a property in the instance and the entire instance must validate against the dependency value.
+
+[reference](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.2.2.4)
+
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| opts | [<code>object</code>](#object) | 
 
 <a name="propertyNames"></a>
 
 ## propertyNames(value) ⇒ <code>FluentSchema</code>
-
 If the instance is an object, this keyword validates if every property name in the instance validates against the provided schema.
 Note the property name that the schema is testing will always be a string.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.5.8)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                      |
-| ----- | ------------------------- |
-| value | <code>FluentSchema</code> |
+| Param | Type |
+| --- | --- |
+| value | <code>FluentSchema</code> | 
 
 <a name="prop"></a>
 
 ## prop(name, props) ⇒ <code>FluentSchema</code>
-
 The value of "properties" MUST be an object. Each value of this object MUST be a valid JSON Schema.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.5.4)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| name  | [<code>string</code>](#string) |
-| props | <code>FluentSchema</code>      |
+| Param | Type |
+| --- | --- |
+| name | [<code>string</code>](#string) | 
+| props | <code>FluentSchema</code> | 
+
+<a name="only"></a>
+
+## only(properties) ⇒ [<code>ObjectSchema</code>](#ObjectSchema)
+Returns an object schema with only a subset of keys provided
+
+**Kind**: global function  
+
+| Param | Description |
+| --- | --- |
+| properties | a list of properties you want to keep |
 
 <a name="definition"></a>
 
 ## definition(name, props) ⇒ <code>FluentSchema</code>
-
 The "definitions" keywords provides a standardized location for schema authors to inline re-usable JSON Schemas into a more general schema.
 There are no restrictions placed on the values within the array.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.9)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| name  | [<code>string</code>](#string) |
-| props | <code>FluentSchema</code>      |
+| Param | Type |
+| --- | --- |
+| name | [<code>string</code>](#string) | 
+| props | <code>FluentSchema</code> | 
 
 <a name="RawSchema"></a>
 
 ## RawSchema(schema) ⇒ <code>FluentSchema</code>
-
 Represents a raw JSON Schema that will be parsed
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param  | Type                |
-| ------ | ------------------- |
-| schema | <code>Object</code> |
+| Param | Type |
+| --- | --- |
+| schema | <code>Object</code> | 
 
 <a name="StringSchema"></a>
 
 ## StringSchema([options]) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 Represents a StringSchema.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param                 | Type                                       | Default            | Description                                        |
-| --------------------- | ------------------------------------------ | ------------------ | -------------------------------------------------- |
-| [options]             | <code>Object</code>                        |                    | Options                                            |
-| [options.schema]      | [<code>StringSchema</code>](#StringSchema) |                    | Default schema                                     |
-| [options.generateIds] | [<code>boolean</code>](#boolean)           | <code>false</code> | generate the id automatically e.g. #properties.foo |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> |  | Options |
+| [options.schema] | [<code>StringSchema</code>](#StringSchema) |  | Default schema |
+| [options.generateIds] | [<code>boolean</code>](#boolean) | <code>false</code> | generate the id automatically e.g. #properties.foo |
 
 <a name="minLength"></a>
 
 ## minLength(min) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 A string instance is valid against this keyword if its length is greater than, or equal to, the value of this keyword.
 The length of a string instance is defined as the number of its characters as defined by RFC 7159 [RFC7159].
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.3.2)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| min   | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| min | [<code>number</code>](#number) | 
 
 <a name="maxLength"></a>
 
 ## maxLength(max) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 A string instance is valid against this keyword if its length is less than, or equal to, the value of this keyword.
 The length of a string instance is defined as the number of its characters as defined by RFC 7159 [RFC7159].
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.3.1)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param | Type                           |
-| ----- | ------------------------------ |
-| max   | [<code>number</code>](#number) |
+| Param | Type |
+| --- | --- |
+| max | [<code>number</code>](#number) | 
 
 <a name="format"></a>
 
 ## format(format) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 A string value can be RELATIVE_JSON_POINTER, JSON_POINTER, UUID, REGEX, IPV6, IPV4, HOSTNAME, EMAIL, URL, URI_TEMPLATE, URI_REFERENCE, URI, TIME, DATE,
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.7.3)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param  | Type                           |
-| ------ | ------------------------------ |
-| format | [<code>string</code>](#string) |
+| Param | Type |
+| --- | --- |
+| format | [<code>string</code>](#string) | 
 
 <a name="pattern"></a>
 
 ## pattern(pattern) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 This string SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect.
-A string instance is considered valid if the regular expression matches the instance successfully.
+ A string instance is considered valid if the regular expression matches the instance successfully.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.3.3)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param   | Type                           |
-| ------- | ------------------------------ |
-| pattern | [<code>string</code>](#string) |
+| Param | Type |
+| --- | --- |
+| pattern | [<code>string</code>](#string) | 
 
 <a name="contentEncoding"></a>
 
 ## contentEncoding(encoding) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 If the instance value is a string, this property defines that the string SHOULD
-be interpreted as binary data and decoded using the encoding named by this property.
-RFC 2045, Sec 6.1 [RFC2045] lists the possible values for this property.
+ be interpreted as binary data and decoded using the encoding named by this property.
+ RFC 2045, Sec 6.1 [RFC2045] lists the possible values for this property.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.8.3)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param    | Type                           |
-| -------- | ------------------------------ |
-| encoding | [<code>string</code>](#string) |
+| Param | Type |
+| --- | --- |
+| encoding | [<code>string</code>](#string) | 
 
 <a name="contentMediaType"></a>
 
 ## contentMediaType(mediaType) ⇒ [<code>StringSchema</code>](#StringSchema)
-
 The value of this property must be a media type, as defined by RFC 2046 [RFC2046].
-This property defines the media type of instances which this schema defines.
+ This property defines the media type of instances which this schema defines.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.8.4)
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param     | Type                           |
-| --------- | ------------------------------ |
-| mediaType | [<code>string</code>](#string) |
+| Param | Type |
+| --- | --- |
+| mediaType | [<code>string</code>](#string) | 
+

--- a/src/FluentJSONSchema.d.ts
+++ b/src/FluentJSONSchema.d.ts
@@ -124,6 +124,8 @@ export interface ObjectSchema extends BaseSchema<ObjectSchema> {
   propertyNames: (value: JSONSchema) => ObjectSchema
   extend: (schema: ObjectSchema | ExtendedSchema) => ExtendedSchema
   only: (properties: string[]) => ObjectSchema
+  dependentRequired: (options: DependentRequiredOptions) => ObjectSchema
+  dependentSchemas: (options: DependentSchemaOptions) => ObjectSchema
 }
 
 export type ExtendedSchema = Pick<ObjectSchema, 'isFluentSchema' | 'extend'>
@@ -217,6 +219,15 @@ interface PatternPropertiesOptions {
 interface DependenciesOptions {
   [key: string]: JSONSchema[]
 }
+
+interface DependentSchemaOptions {
+  [key: string]: JSONSchema
+}
+
+interface DependentRequiredOptions {
+  [key: string]: string[]
+}
+
 export function withOptions<T>(options: SchemaOptions): T
 
 export interface S extends BaseSchema<S> {

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -501,7 +501,89 @@ describe('ObjectSchema', () => {
           ).toEqual(value)
         ).toThrowError(
           new S.FluentSchemaError(
-            "'dependencies' invalid options. Provide a valid map e.g. { 'foo': ['ba'] } or { 'foo': S.string() }"
+            "'dependencies' invalid options. Provide a valid map e.g. { 'foo': ['bar'] } or { 'foo': S.string() }"
+          )
+        )
+      })
+    })
+
+    describe('dependentRequired', () => {
+      it('valid', () => {
+        expect(
+          ObjectSchema()
+            .dependentRequired({
+              foo: ['bar'],
+            })
+            .prop('foo')
+            .prop('bar')
+            .valueOf()
+        ).toEqual({
+          type: 'object',
+          dependentRequired: {
+            foo: [ 'bar' ]
+          },
+          properties: {
+            foo: {},
+            bar: {}
+          }
+        })
+      })
+
+      it('invalid', () => {
+        const value = {
+          foo: ObjectSchema().prop('bar', S.string()),
+        }
+
+        expect(() => {
+          expect(
+            ObjectSchema()
+              .dependentRequired(value)
+              .prop('foo')
+          ).toEqual(value)
+        }).toThrowError(
+          new S.FluentSchemaError(
+            "'dependentRequired' invalid options. Provide a valid array e.g. { 'foo': ['bar'] }"
+          )
+        )
+      })
+    })
+
+    describe('dependentSchemas', () => {
+      it('valid', () => {
+        expect(
+          ObjectSchema()
+            .dependentSchemas({
+              foo: ObjectSchema().prop('bar', S.string())
+            })
+            .prop('foo')
+            .valueOf()
+        ).toEqual({
+          dependentSchemas: {
+            foo: {
+              properties: {
+                bar: { type: 'string' },
+              },
+            },
+          },
+          properties: { foo: {} },
+          type: 'object',
+        })
+      })
+
+      it('invalid', () => {
+        const value = {
+          foo: ['bar']
+        }
+
+        expect(() => {
+          expect(
+            ObjectSchema()
+              .dependentSchemas(value)
+              .prop('foo')
+          ).toEqual(value)
+        }).toThrowError(
+          new S.FluentSchemaError(
+            "'dependentSchemas' invalid options. Provide a valid schema e.g. { 'foo': S.string() }"
           )
         )
       })

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -21,18 +21,12 @@ const schema = S.object()
   .prop('email', S.string().format('email'))
   .prop(
     'avatar',
-    S.string()
-      .contentEncoding('base64')
-      .contentMediaType('image/png')
+    S.string().contentEncoding('base64').contentMediaType('image/png')
   )
   .required()
   .prop(
     'password',
-    S.string()
-      .default('123456')
-      .minLength(6)
-      .maxLength(12)
-      .pattern('.*')
+    S.string().default('123456').minLength(6).maxLength(12).pattern('.*')
   )
   .required()
   .prop('addresses', S.array().items([S.ref('#address')]))
@@ -68,3 +62,22 @@ const userSchema = S.object()
   .valueOf()
 
 console.log('user:\n', JSON.stringify(userSchema))
+
+const dependentRequired = S.object()
+  .dependentRequired({
+    foo: ['bar'],
+  })
+  .prop('foo')
+  .prop('bar')
+  .valueOf()
+
+console.log('dependentRequired:\n', JSON.stringify(dependentRequired))
+
+const dependentSchemas = S.object()
+  .dependentSchemas({
+    foo: S.object().prop('bar'),
+  })
+  .prop('foo', S.object().prop('bar'))
+  .valueOf()
+
+console.log('dependentRequired:\n', JSON.stringify(dependentSchemas))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,3 +98,22 @@ const rawNullableSchema = S.object()
   .prop('hello', S.string())
 
 console.log('raw schema with nullable props\n', JSON.stringify(rawNullableSchema))
+
+const dependentRequired = S.object()
+  .dependentRequired({
+    foo: ['bar'],
+  })
+  .prop('foo')
+  .prop('bar')
+  .valueOf()
+
+console.log('dependentRequired:\n', JSON.stringify(dependentRequired))
+
+const dependentSchemas = S.object()
+  .dependentSchemas({
+    foo: S.object().prop('bar'),
+  })
+  .prop('foo', S.object().prop('bar'))
+  .valueOf()
+
+console.log('dependentRequired:\n', JSON.stringify(dependentSchemas))


### PR DESCRIPTION
Adds `dependentRequired` and `dependentSchemas` support since the `dependencies` was split into these keys

https://json-schema.org/draft/2019-09/release-notes.html

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Related issue: https://github.com/fastify/fluent-json-schema/issues/135