### PR TITLE
Object schema without

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,10 +295,12 @@ const userSchema = S.object()
 console.log(userSchema)
 ```
 
-## Selecting only certain properties of your schema
+## Selecting certain properties of your schema
 
 In addition to extending schemas, it is also possible to reduce them into smaller schemas. This comes in handy
 when you have a large Fluent Schema, and would like to re-use some of its properties.
+
+Select only properties you want to keep.
 
 ```js
 const S = require('fluent-json-schema')
@@ -310,6 +312,20 @@ const userSchema = S.object()
   .prop('updatedAt', S.string().format('time'))
 
 const loginSchema = userSchema.only(['username', 'password'])
+```
+
+Or remove properties you dont want to keep.
+
+```js
+const S = require('fluent-json-schema')
+const personSchema = S.object()
+  .prop('name', S.string())
+  .prop('age', S.number())
+  .prop('id', S.string().format('uuid'))
+  .prop('createdAt', S.string().format('time'))
+  .prop('updatedAt', S.string().format('time'))
+
+const bodySchema = personSchema.without(['createdAt', 'updatedAt'])
 ```
 
 ### Detect Fluent Schema objects

--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -178,23 +178,23 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
      */
 
     dependentRequired: opts => {
-      const values = Object.entries(opts).reduce((memo, [prop, schema]) => {
-        if (!Array.isArray(schema))
-          throw new FluentSchemaError(
-            "'dependentRequired' invalid options. Provide a valid array e.g. { 'foo': ['bar'] }"
-          )
-        return {
-          ...memo,
-          [prop]: schema,
-        }
-      }, {})
+    const values = Object.entries(opts).reduce((memo, [prop, schema]) => {
+      if (!Array.isArray(schema))
+        throw new FluentSchemaError(
+          "'dependentRequired' invalid options. Provide a valid array e.g. { 'foo': ['bar'] }"
+        )
+      return {
+        ...memo,
+        [prop]: schema,
+      }
+    }, {})
 
-      return setAttribute({ schema, ...options }, [
-        'dependentRequired',
-        values,
-        'object',
-      ])
-    },
+    return setAttribute({ schema, ...options }, [
+      'dependentRequired',
+      values,
+      'object',
+    ])
+  },
 
     /**
      * The value of "properties" MUST be an object. The dependency value MUST be a valid JSON Schema.
@@ -204,25 +204,25 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
      * @param {object} opts
      * @returns {FluentSchema}
      */
-    dependentSchemas: opts => {
-      const values = Object.entries(opts).reduce((memo, [prop, schema]) => {
-        if (!isFluentSchema(schema))
-          throw new FluentSchemaError(
-            "'dependentSchemas' invalid options. Provide a valid schema e.g. { 'foo': S.string() }"
-          )
+  dependentSchemas: opts => {
+    const values = Object.entries(opts).reduce((memo, [prop, schema]) => {
+      if (!isFluentSchema(schema))
+        throw new FluentSchemaError(
+          "'dependentSchemas' invalid options. Provide a valid schema e.g. { 'foo': S.string() }"
+        )
 
-        return {
-          ...memo,
-          [prop]: omit(schema.valueOf({ isRoot: false }), ['$schema', 'type', 'definitions']),
-        }
-      }, {})
+      return {
+        ...memo,
+        [prop]: omit(schema.valueOf({ isRoot: false }), ['$schema', 'type', 'definitions']),
+      }
+    }, {})
 
-      return setAttribute({ schema, ...options }, [
-        'dependentSchemas',
-        values,
-        'object',
-      ])
-    },
+    return setAttribute({ schema, ...options }, [
+      'dependentSchemas',
+      values,
+      'object',
+    ])
+  },
 
     /**
      * If the instance is an object, this keyword validates if every property name in the instance validates against the provided schema.

--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -178,23 +178,23 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
      */
 
     dependentRequired: opts => {
-    const values = Object.entries(opts).reduce((memo, [prop, schema]) => {
-      if (!Array.isArray(schema))
-        throw new FluentSchemaError(
-          "'dependentRequired' invalid options. Provide a valid array e.g. { 'foo': ['bar'] }"
-        )
-      return {
-        ...memo,
-        [prop]: schema,
-      }
-    }, {})
+      const values = Object.entries(opts).reduce((memo, [prop, schema]) => {
+        if (!Array.isArray(schema))
+          throw new FluentSchemaError(
+            "'dependentRequired' invalid options. Provide a valid array e.g. { 'foo': ['bar'] }"
+          )
+        return {
+          ...memo,
+          [prop]: schema,
+        }
+      }, {})
 
-    return setAttribute({ schema, ...options }, [
-      'dependentRequired',
-      values,
-      'object',
-    ])
-  },
+      return setAttribute({ schema, ...options }, [
+        'dependentRequired',
+        values,
+        'object',
+      ])
+    },
 
     /**
      * The value of "properties" MUST be an object. The dependency value MUST be a valid JSON Schema.
@@ -204,25 +204,25 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
      * @param {object} opts
      * @returns {FluentSchema}
      */
-  dependentSchemas: opts => {
-    const values = Object.entries(opts).reduce((memo, [prop, schema]) => {
-      if (!isFluentSchema(schema))
-        throw new FluentSchemaError(
-          "'dependentSchemas' invalid options. Provide a valid schema e.g. { 'foo': S.string() }"
-        )
+    dependentSchemas: opts => {
+      const values = Object.entries(opts).reduce((memo, [prop, schema]) => {
+        if (!isFluentSchema(schema))
+          throw new FluentSchemaError(
+            "'dependentSchemas' invalid options. Provide a valid schema e.g. { 'foo': S.string() }"
+          )
 
-      return {
-        ...memo,
-        [prop]: omit(schema.valueOf({ isRoot: false }), ['$schema', 'type', 'definitions']),
-      }
-    }, {})
+        return {
+          ...memo,
+          [prop]: omit(schema.valueOf({ isRoot: false }), ['$schema', 'type', 'definitions']),
+        }
+      }, {})
 
-    return setAttribute({ schema, ...options }, [
-      'dependentSchemas',
-      values,
-      'object',
-    ])
-  },
+      return setAttribute({ schema, ...options }, [
+        'dependentSchemas',
+        values,
+        'object',
+      ])
+    },
 
     /**
      * If the instance is an object, this keyword validates if every property name in the instance validates against the provided schema.
@@ -344,10 +344,25 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
       return ObjectSchema({
         schema: {
           ...schema,
-          properties: schema.properties.filter(p =>
-            properties.includes(p.name)
-          ),
+          properties: schema.properties.filter(({ name }) => properties.includes(name)),
           required: schema.required.filter(p => properties.includes(p)),
+        },
+        ...options,
+      })
+    },
+
+    /**
+     * Returns an object schema without a subset of keys provided
+     *
+     * @param properties a list of properties you dont want to keep
+     * @returns {ObjectSchema}
+     */
+    without: properties => {
+      return ObjectSchema({
+        schema: {
+          ...schema,
+          properties: schema.properties.filter(p => !properties.includes(p.name)),
+          required: schema.required.filter(p => !properties.includes(p)),
         },
         ...options,
       })

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -520,7 +520,7 @@ describe('ObjectSchema', () => {
         ).toEqual({
           type: 'object',
           dependentRequired: {
-            foo: ['bar']
+            foo: [ 'bar' ]
           },
           properties: {
             foo: {},

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -520,7 +520,7 @@ describe('ObjectSchema', () => {
         ).toEqual({
           type: 'object',
           dependentRequired: {
-            foo: [ 'bar' ]
+            foo: ['bar']
           },
           properties: {
             foo: {},
@@ -940,6 +940,68 @@ describe('ObjectSchema', () => {
           },
         },
         required: ['foo'],
+        type: 'object',
+      })
+    })
+  })
+
+  describe('without', () => {
+    it('returns a subset of the object', () => {
+      const base = S.object()
+        .id('base')
+        .title('base')
+        .prop('foo', S.string())
+        .prop('bar', S.string())
+        .prop('baz', S.string())
+        .prop(
+          'children',
+          S.object()
+            .prop('alpha', S.string())
+            .prop('beta', S.string())
+        )
+
+      const without = base.without(['foo', 'children'])
+
+      expect(without.valueOf()).toEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'base',
+        title: 'base',
+        properties: {
+          bar: {
+            type: 'string',
+          },
+          baz: {
+            type: 'string',
+          },
+        },
+        type: 'object',
+      })
+    })
+
+    it('works correctly with required properties', () => {
+      const base = S.object()
+        .id('base')
+        .title('base')
+        .prop('foo', S.string().required())
+        .prop('bar', S.string())
+        .prop('baz', S.string().required())
+        .prop('qux', S.string())
+
+      const without = base.without(['foo', 'bar'])
+
+      expect(without.valueOf()).toEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'base',
+        title: 'base',
+        properties: {
+          baz: {
+            type: 'string',
+          },
+          qux: {
+            type: 'string',
+          },
+        },
+        required: ['baz'],
         type: 'object',
       })
     })


### PR DESCRIPTION
This pull request adds 'without' method to ObjectSchema;

Sometimes when you have a large Fluent Schema becomes difficult to reuse it selecting only some of its properties. It makes more sense to reuse by removing properties you don't want to keep.

Example:

```js
const S = require('fluent-json-schema')
const personSchema = S.object()
  .prop('id', S.string().format('uuid'))
  .prop('name', S.string())
  .prop('age', S.number())
  .prop('gender', S.string())
  .prop(
            'address',
            S.object()
              .prop('city', S.string())
              .prop('street', S.string())
              .prop('zipCode', S.string())
          )
  .prop('profession', S.string())
  .prop('createdAt', S.string().format('time'))
  .prop('updatedAt', S.string().format('time'))

// looks better
const bodySchema = personSchema.without(['createdAt', 'updatedAt'])

// then this
const bodySchema = personSchema.only(['id', 'name', 'age', 'gender', 'address', 'profession'])
```

![image](https://user-images.githubusercontent.com/51336150/148621623-4c3b3884-4aa8-4a1f-bdda-ee0b602697df.png)


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
