### PR TITLE
adding deprecated function to BaseSchema

### DIFF
--- a/src/BaseSchema.js
+++ b/src/BaseSchema.js
@@ -4,6 +4,7 @@ const {
   omit,
   isFluentSchema,
   last,
+  isBoolean,
   isUniq,
   patchIdsWithParentId,
   REQUIRED,
@@ -176,6 +177,20 @@ const BaseSchema = (
   writeOnly: isWriteOnly => {
     const value = isWriteOnly !== undefined ? isWriteOnly : true
     return setAttribute({ schema, ...options }, ['writeOnly', value, 'boolean'])
+  },
+
+  /**
+   * The value of deprecated can be left empty to indicate the property is deprecated.
+   * It takes an optional boolean which can be used to explicitly set deprecated true/false.
+   *
+   * {@link https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.3|reference}
+   * @param {Boolean} isDeprecated
+   * @returns {BaseSchema}
+   */
+  deprecated: (isDeprecated) => {
+    if(isDeprecated && !isBoolean(isDeprecated)) throw new FluentSchemaError("'deprecated' must be a boolean value")
+    const value = isDeprecated !== undefined ? isDeprecated : true
+    return setAttribute({ schema, ...options }, ['deprecated', value, 'boolean'])
   },
 
   /**

--- a/src/BaseSchema.test.js
+++ b/src/BaseSchema.test.js
@@ -212,6 +212,171 @@ describe('BaseSchema', () => {
       })
     })
 
+    describe('deprecated', () => {
+      it('valid', () => {
+        expect(
+          BaseSchema()
+            .deprecated(true)
+            .valueOf().deprecated
+        ).toEqual(true)
+      })
+      it('invalid', () => {
+        expect(
+          () =>
+            BaseSchema()
+              .deprecated('somethingNotBoolean')
+              .valueOf().deprecated
+        ).toThrowError(
+          new S.FluentSchemaError(
+            "'deprecated' must be a boolean value"
+          )
+        )
+      })
+      it('valid with no value', () => {
+        expect(
+          BaseSchema()
+            .deprecated()
+            .valueOf().deprecated
+        ).toEqual(true)
+      })
+      it('can be set to false', () => {
+        expect(
+          BaseSchema()
+            .deprecated(false)
+            .valueOf().deprecated
+        ).toEqual(false)
+      })
+      it('property', () => {
+        expect(
+          S.object()
+            .prop('foo', S.string())
+            .prop('bar', S.string().deprecated())
+            .valueOf()
+        ).toEqual({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          properties: {
+            bar: { type: 'string', deprecated: true },
+            foo: { type: 'string' }
+          },
+          type: 'object',
+        })
+      });
+      it('object', () => {
+        expect(
+          S.object()
+            .prop('foo', S.string())
+            .prop('bar', S
+              .object()
+              .deprecated()
+              .prop('raz', S.string())
+              .prop('iah', S.number()))
+            .valueOf()
+        ).toEqual({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          properties: {
+            foo: { type: 'string' },
+            bar: {
+              type: 'object',
+              deprecated: true,
+              properties: {
+                raz: { type: 'string' },
+                iah: { type: 'number' }
+              },
+            },
+          },
+          type: 'object',
+        })
+      });
+      it('object property', () => {
+        expect(
+          S.object()
+            .prop('foo', S.string())
+            .prop('bar', S
+              .object()
+              .prop('raz', S.string().deprecated())
+              .prop('iah', S.number())
+            )
+            .valueOf()
+        ).toEqual({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          properties: {
+            foo: { type: 'string' },
+            bar: {
+              type: 'object',
+              properties: {
+                raz: { type: 'string', deprecated: true },
+                iah: { type: 'number' }
+              },
+            },
+          },
+          type: 'object',
+        })
+      });
+      it('array', () => {
+        expect(
+          S.object()
+            .prop('foo', S.string())
+            .prop('bar', S
+              .array()
+              .deprecated()
+              .items(S.number())
+            )
+            .valueOf()
+        ).toEqual({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            foo: { type: 'string' },
+            bar: {
+              type: 'array',
+              deprecated: true,
+              items: { type: 'number' }
+            }
+          },
+        })
+      });
+      it('array item', () => {
+        expect(
+          S.object()
+            .prop('foo', S.string())
+            .prop('bar', S
+              .array()
+              .items([
+                S.object().prop('zoo', S.string()).prop('biz', S.string()),
+                S.object().deprecated().prop('zal', S.string()).prop('boz', S.string())
+              ])
+            )
+            .valueOf()
+        ).toEqual({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            foo: { type: 'string' },
+            bar: {
+              type: 'array',
+              items: [
+                {
+                  type: 'object',
+                  properties: {
+                    zoo: { type: 'string' },
+                    biz: { type: 'string' }
+                  }
+                },
+                {
+                  type: 'object',
+                  deprecated: true,
+                  properties: {
+                    zal: { type: 'string' },
+                    boz: { type: 'string' }
+                  }
+                }
+              ]
+            }
+          },
+        })
+      });
+    })
+
     describe('enum', () => {
       it('valid', () => {
         const value = ['VALUE']

--- a/src/FluentJSONSchema.d.ts
+++ b/src/FluentJSONSchema.d.ts
@@ -20,6 +20,7 @@ export interface BaseSchema<T> {
   oneOf: (schema: Array<JSONSchema>) => T
   readOnly: (isReadOnly?: boolean) => T
   writeOnly: (isWriteOnly?: boolean) => T
+  deprecated: (isDeprecated?: boolean) => T
   isFluentSchema: boolean
   isFluentJSONSchema: boolean
   raw: (fragment: any) => T
@@ -124,6 +125,7 @@ export interface ObjectSchema extends BaseSchema<ObjectSchema> {
   propertyNames: (value: JSONSchema) => ObjectSchema
   extend: (schema: ObjectSchema | ExtendedSchema) => ExtendedSchema
   only: (properties: string[]) => ObjectSchema
+  without: (properties: string[]) => ObjectSchema
   dependentRequired: (options: DependentRequiredOptions) => ObjectSchema
   dependentSchemas: (options: DependentSchemaOptions) => ObjectSchema
 }

--- a/src/MixedSchema.js
+++ b/src/MixedSchema.js
@@ -1,5 +1,4 @@
 'use strict'
-const { BaseSchema } = require('./BaseSchema')
 const { NullSchema } = require('./NullSchema')
 const { BooleanSchema } = require('./BooleanSchema')
 const { StringSchema } = require('./StringSchema')

--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -361,7 +361,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
       return ObjectSchema({
         schema: {
           ...schema,
-          properties: schema.properties.filter(p => !properties.includes(p.name)),
+          properties: schema.properties.filter(({ name }) => !properties.includes(name)),
           required: schema.required.filter(p => !properties.includes(p)),
         },
         ...options,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,6 +75,17 @@ const userSubsetSchema = largeUserSchema.only(['username', 'password'])
 
 console.log('user subset:', JSON.stringify(userSubsetSchema.valueOf()))
 
+const personSchema = S.object()
+  .prop('name', S.string())
+  .prop('age', S.number())
+  .prop('id', S.string().format('uuid'))
+  .prop('createdAt', S.string().format('time'))
+  .prop('updatedAt', S.string().format('time'))
+
+const bodySchema = personSchema.without(['createdAt', 'updatedAt'])
+
+console.log('person subset:', JSON.stringify(bodySchema.valueOf()))
+
 try {
   S.object().prop('foo', 'boom!' as any)
 } catch (e) {
@@ -117,3 +128,10 @@ const dependentSchemas = S.object()
   .valueOf()
 
 console.log('dependentRequired:\n', JSON.stringify(dependentSchemas))
+
+const deprecatedSchema =  S.object()
+    .deprecated()
+    .prop('foo', S.string().deprecated())
+    .valueOf()
+
+console.log('deprecatedSchema:\n', JSON.stringify(deprecatedSchema))

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,8 @@ const last = array => {
 
 const isUniq = array => array.filter((v, i, a) => a.indexOf(v) === i).length === array.length;
 
+const isBoolean = value => 'boolean' === typeof value;
+
 const omit = (obj, props) =>
   Object.entries(obj).reduce((memo, [key, value]) => {
     if (props.includes(key)) return memo
@@ -218,6 +220,7 @@ module.exports = {
   FluentSchemaError,
   last,
   isUniq,
+  isBoolean,
   flat,
   toArray,
   omit,


### PR DESCRIPTION
Adding support to `deprecated` values.

 [Reference](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.3):
```
The value of this keyword MUST be a boolean. When multiple occurrences of this keyword are applicable to a single sub-instance, applications SHOULD consider the instance location to be deprecated if any occurrence specifies a true value.

If "deprecated" has a value of boolean true, it indicates that applications SHOULD refrain from usage of the declared property. It MAY mean the property is going to be removed in the future.

A root schema containing "deprecated" with a value of true indicates that the entire resource being described MAY be removed in the future.

When the "deprecated" keyword is applied to an item in an array by means of "items", if "items" is a single schema, the deprecation relates to the whole array, while if "items" is an array of schemas, the deprecation relates to the corrosponding item according to the subschemas position.

Omitting this keyword has the same behavior as a value of false.
```


![image](https://user-images.githubusercontent.com/51336150/149062601-3877d252-83cf-4da7-85d1-dc7b6c437f8e.png)


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
