### PR TITLE
chore: fix husky git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .editorconfig
 .gitignore
+.husky
 .npmignore
 .nvmrc
 .prettierrc

--- a/package.json
+++ b/package.json
@@ -26,11 +26,6 @@
     "type": "git",
     "url": "https://github.com/fastify/fluent-json-schema.git"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.js",
@@ -54,6 +49,7 @@
     "test:coverage": "jest --coverage && npm run test:typescript",
     "test:watch": "jest src/*.test.js --verbose --watch",
     "test:typescript": "tsd",
+    "prepare": "husky install",
     "format": "prettier --write ./src/**/*.js",
     "coverage": "jest src/**.test.js --coverage",
     "doc": "jsdoc2md ./src/*.js > docs/API.md"


### PR DESCRIPTION
Husky hooks were moved from `package.json` and `.huskyrc.json` to `.husky` directory in Husky v6.
See https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v8

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
