### PR TITLE
test: tidy test syntax

### DIFF
--- a/src/ArraySchema.test.js
+++ b/src/ArraySchema.test.js
@@ -48,7 +48,7 @@ describe('ArraySchema', () => {
         })
       })
       it('invalid', () => {
-        expect(() => ArraySchema().items('')).toThrowError(
+        expect(() => ArraySchema().items('')).toThrow(
           new S.FluentSchemaError("'items' must be a S or an array of S")
         )
       })
@@ -80,7 +80,7 @@ describe('ArraySchema', () => {
         })
       })
       it('invalid', () => {
-        expect(() => ArraySchema().additionalItems('')).toThrowError(
+        expect(() => ArraySchema().additionalItems('')).toThrow(
           new S.FluentSchemaError("'additionalItems' must be a boolean or a S")
         )
       })
@@ -102,7 +102,7 @@ describe('ArraySchema', () => {
           ArraySchema()
             .contains('')
             .valueOf()
-        ).toThrowError(new S.FluentSchemaError("'contains' must be a S"))
+        ).toThrow(new S.FluentSchemaError("'contains' must be a S"))
       })
     })
 
@@ -122,7 +122,7 @@ describe('ArraySchema', () => {
           ArraySchema()
             .uniqueItems('invalid')
             .valueOf()
-        ).toThrowError(
+        ).toThrow(
           new S.FluentSchemaError("'uniqueItems' must be a boolean")
         )
       })
@@ -144,7 +144,7 @@ describe('ArraySchema', () => {
           ArraySchema()
             .minItems('3')
             .valueOf()
-        ).toThrowError(new S.FluentSchemaError("'minItems' must be a integer"))
+        ).toThrow(new S.FluentSchemaError("'minItems' must be a integer"))
       })
     })
 
@@ -164,7 +164,7 @@ describe('ArraySchema', () => {
           ArraySchema()
             .maxItems('5')
             .valueOf()
-        ).toThrowError(new S.FluentSchemaError("'maxItems' must be a integer"))
+        ).toThrow(new S.FluentSchemaError("'maxItems' must be a integer"))
       })
     })
 

--- a/src/BaseSchema.test.js
+++ b/src/BaseSchema.test.js
@@ -218,7 +218,7 @@ describe('BaseSchema', () => {
           BaseSchema()
             .deprecated(true)
             .valueOf().deprecated
-        ).toEqual(true)
+        ).toBe(true)
       })
       it('invalid', () => {
         expect(
@@ -237,14 +237,14 @@ describe('BaseSchema', () => {
           BaseSchema()
             .deprecated()
             .valueOf().deprecated
-        ).toEqual(true)
+        ).toBe(true)
       })
       it('can be set to false', () => {
         expect(
           BaseSchema()
             .deprecated(false)
             .valueOf().deprecated
-        ).toEqual(false)
+        ).toBe(false)
       })
       it('property', () => {
         expect(
@@ -430,21 +430,21 @@ describe('BaseSchema', () => {
           BaseSchema()
             .readOnly(true)
             .valueOf().readOnly
-        ).toEqual(true)
+        ).toBe(true)
       })
       it('valid with no value', () => {
         expect(
           BaseSchema()
             .readOnly()
             .valueOf().readOnly
-        ).toEqual(true)
+        ).toBe(true)
       })
       it('can be set to false', () => {
         expect(
           BaseSchema()
             .readOnly(false)
             .valueOf().readOnly
-        ).toEqual(false)
+        ).toBe(false)
       })
     })
 
@@ -454,21 +454,21 @@ describe('BaseSchema', () => {
           BaseSchema()
             .writeOnly(true)
             .valueOf().writeOnly
-        ).toEqual(true)
+        ).toBe(true)
       })
       it('valid with no value', () => {
         expect(
           BaseSchema()
             .writeOnly()
             .valueOf().writeOnly
-        ).toEqual(true)
+        ).toBe(true)
       })
       it('can be set to false', () => {
         expect(
           BaseSchema()
             .writeOnly(false)
             .valueOf().writeOnly
-        ).toEqual(false)
+        ).toBe(false)
       })
     })
 

--- a/src/BaseSchema.test.js
+++ b/src/BaseSchema.test.js
@@ -75,7 +75,7 @@ describe('BaseSchema', () => {
       it('invalid', () => {
         expect(() => {
           BaseSchema().id('')
-        }).toThrowError(
+        }).toThrow(
           new S.FluentSchemaError(
             'id should not be an empty fragment <#> or an empty string <> (e.g. #myId)'
           )
@@ -122,7 +122,7 @@ describe('BaseSchema', () => {
             BaseSchema()
               .examples(value)
               .valueOf().examples
-        ).toThrowError(
+        ).toThrow(
           new S.FluentSchemaError(
             "'examples' must be an array e.g. ['1', 'one', 'foo']"
           )
@@ -159,7 +159,7 @@ describe('BaseSchema', () => {
           expect(() => {
             return S.object()
               .prop('A', S.string()).required().required()
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'required' has repeated keys, check your calls to .required()"
             )
@@ -170,7 +170,7 @@ describe('BaseSchema', () => {
             return S.object()
               .prop('A', S.string().required())
               .prop('A', S.string().required())
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'required' has repeated keys, check your calls to .required()"
             )
@@ -181,7 +181,7 @@ describe('BaseSchema', () => {
       it('root-level required', () => {
         expect(() => {
           return S.object().required().valueOf()
-        }).toThrowError(
+        }).toThrow(
           new S.FluentSchemaError(
             "'required' has called on root-level schema, check your calls to .required()"
           )
@@ -226,7 +226,7 @@ describe('BaseSchema', () => {
             BaseSchema()
               .deprecated('somethingNotBoolean')
               .valueOf().deprecated
-        ).toThrowError(
+        ).toThrow(
           new S.FluentSchemaError(
             "'deprecated' must be a boolean value"
           )
@@ -394,7 +394,7 @@ describe('BaseSchema', () => {
             BaseSchema()
               .enum(value)
               .valueOf().examples
-        ).toThrowError(
+        ).toThrow(
           new S.FluentSchemaError(
             "'enums' must be an array with at least an element e.g. ['1', 'one', 'foo']"
           )
@@ -511,7 +511,7 @@ describe('BaseSchema', () => {
         it('not an array', () => {
           expect(() => {
             return BaseSchema().allOf('test')
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'allOf' must be a an array of FluentSchema rather than a 'string'"
             )
@@ -520,7 +520,7 @@ describe('BaseSchema', () => {
         it('not an array of FluentSchema', () => {
           expect(() => {
             return BaseSchema().allOf(['test'])
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'allOf' must be a an array of FluentSchema rather than a 'object'"
             )
@@ -570,7 +570,7 @@ describe('BaseSchema', () => {
         it('not an array', () => {
           expect(() => {
             return BaseSchema().anyOf('test')
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'anyOf' must be a an array of FluentSchema rather than a 'string'"
             )
@@ -579,7 +579,7 @@ describe('BaseSchema', () => {
         it('not an array of FluentSchema', () => {
           expect(() => {
             return BaseSchema().anyOf(['test'])
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'anyOf' must be a an array of FluentSchema rather than a 'object'"
             )
@@ -602,7 +602,7 @@ describe('BaseSchema', () => {
         it('not an array', () => {
           expect(() => {
             return BaseSchema().oneOf('test')
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'oneOf' must be a an array of FluentSchema rather than a 'string'"
             )
@@ -611,7 +611,7 @@ describe('BaseSchema', () => {
         it('not an array of FluentSchema', () => {
           expect(() => {
             return BaseSchema().oneOf(['test'])
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'oneOf' must be a an array of FluentSchema rather than a 'object'"
             )
@@ -648,7 +648,7 @@ describe('BaseSchema', () => {
       it('invalid', () => {
         expect(() => {
           BaseSchema().not(undefined)
-        }).toThrowError(new S.FluentSchemaError("'not' must be a BaseSchema"))
+        }).toThrow(new S.FluentSchemaError("'not' must be a BaseSchema"))
       })
     })
   })
@@ -703,14 +703,14 @@ describe('BaseSchema', () => {
             undefined,
             BaseSchema().description('A User desc')
           )
-        }).toThrowError(
+        }).toThrow(
           new S.FluentSchemaError("'ifClause' must be a BaseSchema")
         )
       })
       it('thenClause', () => {
         expect(() => {
           BaseSchema().ifThen(BaseSchema().id('id'), undefined)
-        }).toThrowError(
+        }).toThrow(
           new S.FluentSchemaError("'thenClause' must be a BaseSchema")
         )
       })
@@ -774,7 +774,7 @@ describe('BaseSchema', () => {
               BaseSchema().description('then'),
               BaseSchema().description('else')
             )
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError("'ifClause' must be a BaseSchema")
           )
         })
@@ -785,7 +785,7 @@ describe('BaseSchema', () => {
               undefined,
               BaseSchema().description('else')
             )
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError("'thenClause' must be a BaseSchema")
           )
         })
@@ -796,7 +796,7 @@ describe('BaseSchema', () => {
               BaseSchema().description('then'),
               undefined
             )
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'elseClause' must be a BaseSchema or a false boolean value"
             )

--- a/src/BooleanSchema.test.js
+++ b/src/BooleanSchema.test.js
@@ -29,7 +29,7 @@ describe('BooleanSchema', () => {
       S.object()
         .prop('prop', S.boolean())
         .valueOf().properties.prop.type
-    ).toEqual('boolean')
+    ).toBe('boolean')
   })
 
   describe('raw', () => {

--- a/src/FluentSchema.integration.test.js
+++ b/src/FluentSchema.integration.test.js
@@ -185,7 +185,7 @@ describe('S', () => {
         state: 'Disney World',
         type: 'business'
       })
-      expect(validate.errors).toEqual(null)
+      expect(validate.errors).toBeNull()
       expect(valid).toBeTruthy()
     })
   })
@@ -217,7 +217,7 @@ describe('S', () => {
 
     it('valid', () => {
       const valid = validate({ foo: 'foo' })
-      expect(validate.errors).toEqual(null)
+      expect(validate.errors).toBeNull()
       expect(valid).toBeTruthy()
     })
   })
@@ -326,7 +326,7 @@ describe('S', () => {
         thenBarA: 'thenBarA',
         thenBarB: 'thenBarB'
       })
-      expect(validate.errors).toEqual(null)
+      expect(validate.errors).toBeNull()
       expect(valid).toBeTruthy()
     })
   })
@@ -495,7 +495,7 @@ describe('S', () => {
           const valid = validate({
             test: null
           })
-          expect(validate.errors).toEqual(null)
+          expect(validate.errors).toBeNull()
           expect(valid).toBeTruthy()
         })
       })

--- a/src/IntegerSchema.test.js
+++ b/src/IntegerSchema.test.js
@@ -45,12 +45,12 @@ describe('IntegerSchema', () => {
         })
       })
       it('invalid number', () => {
-        expect(() => S.integer().minimum('5.1')).toThrowError(
+        expect(() => S.integer().minimum('5.1')).toThrow(
           new S.FluentSchemaError("'minimum' must be a Number")
         )
       })
       it('invalid integer', () => {
-        expect(() => S.integer().minimum(5.1)).toThrowError(
+        expect(() => S.integer().minimum(5.1)).toThrow(
           new S.FluentSchemaError("'minimum' must be an Integer")
         )
       })
@@ -74,12 +74,12 @@ describe('IntegerSchema', () => {
         })
       })
       it('invalid number', () => {
-        expect(() => S.integer().maximum('5.1')).toThrowError(
+        expect(() => S.integer().maximum('5.1')).toThrow(
           new S.FluentSchemaError("'maximum' must be a Number")
         )
       })
       it('invalid float', () => {
-        expect(() => S.integer().maximum(5.1)).toThrowError(
+        expect(() => S.integer().maximum(5.1)).toThrow(
           new S.FluentSchemaError("'maximum' must be an Integer")
         )
       })
@@ -104,12 +104,12 @@ describe('IntegerSchema', () => {
         })
       })
       it('invalid value', () => {
-        expect(() => S.integer().multipleOf('5.1')).toThrowError(
+        expect(() => S.integer().multipleOf('5.1')).toThrow(
           new S.FluentSchemaError("'multipleOf' must be a Number")
         )
       })
       it('invalid integer', () => {
-        expect(() => S.integer().multipleOf(5.1)).toThrowError(
+        expect(() => S.integer().multipleOf(5.1)).toThrow(
           new S.FluentSchemaError("'multipleOf' must be an Integer")
         )
       })
@@ -135,12 +135,12 @@ describe('IntegerSchema', () => {
         })
       })
       it('invalid number', () => {
-        expect(() => S.integer().exclusiveMinimum('5.1')).toThrowError(
+        expect(() => S.integer().exclusiveMinimum('5.1')).toThrow(
           new S.FluentSchemaError("'exclusiveMinimum' must be a Number")
         )
       })
       it('invalid integer', () => {
-        expect(() => S.integer().exclusiveMinimum(5.1)).toThrowError(
+        expect(() => S.integer().exclusiveMinimum(5.1)).toThrow(
           new S.FluentSchemaError("'exclusiveMinimum' must be an Integer")
         )
       })
@@ -165,12 +165,12 @@ describe('IntegerSchema', () => {
         })
       })
       it('invalid number', () => {
-        expect(() => S.integer().exclusiveMaximum('5.1')).toThrowError(
+        expect(() => S.integer().exclusiveMaximum('5.1')).toThrow(
           new S.FluentSchemaError("'exclusiveMaximum' must be a Number")
         )
       })
       it('invalid integer', () => {
-        expect(() => S.integer().exclusiveMaximum(5.1)).toThrowError(
+        expect(() => S.integer().exclusiveMaximum(5.1)).toThrow(
           new S.FluentSchemaError("'exclusiveMaximum' must be an Integer")
         )
       })

--- a/src/MixedSchema.test.js
+++ b/src/MixedSchema.test.js
@@ -51,7 +51,7 @@ describe('MixedSchema', () => {
       const types = ''
       expect(() => {
         S.mixed(types)
-      }).toThrowError(
+      }).toThrow(
         new S.FluentSchemaError(
           "Invalid 'types'. It must be an array of types. Valid types are string | number | boolean | integer | object | array | null"
         )
@@ -62,7 +62,7 @@ describe('MixedSchema', () => {
       const types = ['string', 'invalid']
       expect(() => {
         S.mixed(types)
-      }).toThrowError(
+      }).toThrow(
         new S.FluentSchemaError(
           "Invalid 'types'. It must be an array of types. Valid types are string | number | boolean | integer | object | array | null"
         )

--- a/src/NullSchema.test.js
+++ b/src/NullSchema.test.js
@@ -29,7 +29,7 @@ describe('NullSchema', () => {
       S.object()
         .prop('prop', S.null())
         .valueOf().properties.prop.type
-    ).toEqual('null')
+    ).toBe('null')
   })
 
   describe('raw', () => {

--- a/src/NumberSchema.test.js
+++ b/src/NumberSchema.test.js
@@ -45,7 +45,7 @@ describe('NumberSchema', () => {
         })
       })
       it('invalid value', () => {
-        expect(() => S.number().minimum('5.1')).toThrowError(
+        expect(() => S.number().minimum('5.1')).toThrow(
           new S.FluentSchemaError("'minimum' must be a Number")
         )
       })
@@ -69,7 +69,7 @@ describe('NumberSchema', () => {
         })
       })
       it('invalid value', () => {
-        expect(() => S.number().maximum('5.1')).toThrowError(
+        expect(() => S.number().maximum('5.1')).toThrow(
           new S.FluentSchemaError("'maximum' must be a Number")
         )
       })
@@ -94,7 +94,7 @@ describe('NumberSchema', () => {
         })
       })
       it('invalid value', () => {
-        expect(() => S.number().multipleOf('5.1')).toThrowError(
+        expect(() => S.number().multipleOf('5.1')).toThrow(
           new S.FluentSchemaError("'multipleOf' must be a Number")
         )
       })
@@ -120,7 +120,7 @@ describe('NumberSchema', () => {
         })
       })
       it('invalid value', () => {
-        expect(() => S.number().exclusiveMinimum('5.1')).toThrowError(
+        expect(() => S.number().exclusiveMinimum('5.1')).toThrow(
           new S.FluentSchemaError("'exclusiveMinimum' must be a Number")
         )
       })
@@ -145,7 +145,7 @@ describe('NumberSchema', () => {
         })
       })
       it('invalid value', () => {
-        expect(() => S.number().exclusiveMaximum('5.1')).toThrowError(
+        expect(() => S.number().exclusiveMaximum('5.1')).toThrow(
           new S.FluentSchemaError("'exclusiveMaximum' must be a Number")
         )
       })

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -207,7 +207,7 @@ describe('ObjectSchema', () => {
       ObjectSchema()
         .prop('prop', S.object())
         .valueOf().properties.prop.type
-    ).toEqual('object')
+    ).toBe('object')
   })
 
   it('valueOf', () => {
@@ -627,7 +627,7 @@ describe('ObjectSchema', () => {
 
   describe('null', () => {
     it('sets a type object from the root', () => {
-      expect(S.null().valueOf().type).toEqual('null')
+      expect(S.null().valueOf().type).toBe('null')
     })
 
     it('sets a type object from the prop', () => {
@@ -636,7 +636,7 @@ describe('ObjectSchema', () => {
           .prop('value', S.null())
 
           .valueOf().properties.value.type
-      ).toEqual('null')
+      ).toBe('null')
     })
   })
 

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -96,7 +96,7 @@ describe('ObjectSchema', () => {
           it('invalid', () => {
             expect(() => {
               ObjectSchema().id('')
-            }).toThrowError(
+            }).toThrow(
               new S.FluentSchemaError(
                 'id should not be an empty fragment <#> or an empty string <> (e.g. #myId)'
               )
@@ -303,7 +303,7 @@ describe('ObjectSchema', () => {
         it('throws an error passing a string as value', () => {
           expect(() => {
             ObjectSchema().prop('prop', 'invalid')
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'prop' doesn't support value '\"invalid\"'. Pass a FluentSchema object"
             )
@@ -313,7 +313,7 @@ describe('ObjectSchema', () => {
         it('throws an error passing a number as value', () => {
           expect(() => {
             ObjectSchema().prop('prop', 555)
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'prop' doesn't support value '555'. Pass a FluentSchema object"
             )
@@ -323,7 +323,7 @@ describe('ObjectSchema', () => {
         it('throws an error passing an array as value', () => {
           expect(() => {
             ObjectSchema().prop('prop', [])
-          }).toThrowError(
+          }).toThrow(
             new S.FluentSchemaError(
               "'prop' doesn't support value '[]'. Pass a FluentSchema object"
             )
@@ -370,7 +370,7 @@ describe('ObjectSchema', () => {
               .prop('prop')
               .additionalProperties(value)
           ).toEqual(value)
-        ).toThrowError(
+        ).toThrow(
           new S.FluentSchemaError(
             "'additionalProperties' must be a boolean or a S"
           )
@@ -397,7 +397,7 @@ describe('ObjectSchema', () => {
               .prop('prop')
               .maxProperties(value)
           ).toEqual(value)
-        ).toThrowError(
+        ).toThrow(
           new S.FluentSchemaError("'maxProperties' must be a Integer")
         )
       })
@@ -422,7 +422,7 @@ describe('ObjectSchema', () => {
               .prop('prop')
               .minProperties(value)
           ).toEqual(value)
-        ).toThrowError(
+        ).toThrow(
           new S.FluentSchemaError("'minProperties' must be a Integer")
         )
       })
@@ -452,7 +452,7 @@ describe('ObjectSchema', () => {
               .prop('prop')
               .patternProperties(value)
           ).toEqual(value)
-        ).toThrowError(
+        ).toThrow(
           new S.FluentSchemaError(
             "'patternProperties' invalid options. Provide a valid map e.g. { '^fo.*$': S.string() }"
           )
@@ -509,7 +509,7 @@ describe('ObjectSchema', () => {
               .prop('prop')
               .dependencies(value)
           ).toEqual(value)
-        ).toThrowError(
+        ).toThrow(
           new S.FluentSchemaError(
             "'dependencies' invalid options. Provide a valid map e.g. { 'foo': ['bar'] } or { 'foo': S.string() }"
           )
@@ -550,7 +550,7 @@ describe('ObjectSchema', () => {
               .dependentRequired(value)
               .prop('foo')
           ).toEqual(value)
-        }).toThrowError(
+        }).toThrow(
           new S.FluentSchemaError(
             "'dependentRequired' invalid options. Provide a valid array e.g. { 'foo': ['bar'] }"
           )
@@ -591,7 +591,7 @@ describe('ObjectSchema', () => {
               .dependentSchemas(value)
               .prop('foo')
           ).toEqual(value)
-        }).toThrowError(
+        }).toThrow(
           new S.FluentSchemaError(
             "'dependentSchemas' invalid options. Provide a valid schema e.g. { 'foo': S.string() }"
           )
@@ -620,7 +620,7 @@ describe('ObjectSchema', () => {
               .prop('prop')
               .propertyNames(value)
           ).toEqual(value)
-        ).toThrowError(new S.FluentSchemaError("'propertyNames' must be a S"))
+        ).toThrow(new S.FluentSchemaError("'propertyNames' must be a S"))
       })
     })
   })
@@ -881,7 +881,7 @@ describe('ObjectSchema', () => {
     it('throws an error if a schema is not provided', () => {
       expect(() => {
         S.object().extend()
-      }).toThrowError(
+      }).toThrow(
         new S.FluentSchemaError("Schema can't be null or undefined")
       )
     })
@@ -889,7 +889,7 @@ describe('ObjectSchema', () => {
     it('throws an error if a schema is invalid', () => {
       expect(() => {
         S.object().extend('boom!')
-      }).toThrowError(new S.FluentSchemaError("Schema isn't FluentSchema type"))
+      }).toThrow(new S.FluentSchemaError("Schema isn't FluentSchema type"))
     })
 
     it('throws an error if you append a new prop after extend', () => {
@@ -898,7 +898,7 @@ describe('ObjectSchema', () => {
         S.object()
           .extend(base)
           .prop('foo')
-      }).toThrowError(
+      }).toThrow(
         new S.FluentSchemaError(
           'S.object(...).extend(...).prop is not a function'
         )

--- a/src/RawSchema.test.js
+++ b/src/RawSchema.test.js
@@ -33,7 +33,7 @@ describe('RawSchema', () => {
     })
 
     it("throws an exception if the input isn't an object", () => {
-      expect(() => RawSchema('boom!')).toThrowError(
+      expect(() => RawSchema('boom!')).toThrow(
         new S.FluentSchemaError('A fragment must be a JSON object')
       )
     })

--- a/src/StringSchema.test.js
+++ b/src/StringSchema.test.js
@@ -43,7 +43,7 @@ describe('StringSchema', () => {
         })
       })
       it('invalid', () => {
-        expect(() => StringSchema().minLength('5.1')).toThrowError(
+        expect(() => StringSchema().minLength('5.1')).toThrow(
           new S.FluentSchemaError("'minLength' must be an Integer")
         )
       })
@@ -59,7 +59,7 @@ describe('StringSchema', () => {
         })
       })
       it('invalid', () => {
-        expect(() => StringSchema().maxLength('5.1')).toThrowError(
+        expect(() => StringSchema().maxLength('5.1')).toThrow(
           new S.FluentSchemaError("'maxLength' must be an Integer")
         )
       })
@@ -86,7 +86,7 @@ describe('StringSchema', () => {
         })
       })
       it('invalid', () => {
-        expect(() => StringSchema().format('invalid')).toThrowError(
+        expect(() => StringSchema().format('invalid')).toThrow(
           new S.FluentSchemaError(
             "'format' must be one of relative-json-pointer, json-pointer, uuid, regex, ipv6, ipv4, hostname, email, url, uri-template, uri-reference, uri, time, date, date-time"
           )
@@ -127,7 +127,7 @@ describe('StringSchema', () => {
       })
 
       it('invalid value', () => {
-        expect(() => StringSchema().pattern(1111)).toThrowError(
+        expect(() => StringSchema().pattern(1111)).toThrow(
           new S.FluentSchemaError(
             "'pattern' must be a string or a RegEx (e.g. /.*/)"
           )
@@ -146,7 +146,7 @@ describe('StringSchema', () => {
         })
       })
       it('invalid', () => {
-        expect(() => StringSchema().contentEncoding(1000)).toThrowError(
+        expect(() => StringSchema().contentEncoding(1000)).toThrow(
           new S.FluentSchemaError("'contentEncoding' must be a string")
         )
       })
@@ -163,7 +163,7 @@ describe('StringSchema', () => {
         })
       })
       it('invalid', () => {
-        expect(() => StringSchema().contentMediaType(1000)).toThrowError(
+        expect(() => StringSchema().contentMediaType(1000)).toThrow(
           new S.FluentSchemaError("'contentMediaType' must be a string")
         )
       })


### PR DESCRIPTION
This PR:

- replaces use of `toEqual()` with `toBe()` or `toBeNull()` when expecting primitive literals, as [recommended in Jest documentation](https://jestjs.io/docs/expect#tobevalue)
- replaces `toThrowError()` with its canonical name `toThrow()` as the aliased method is going to be removed in the next major version of Jest, see https://github.com/facebook/jest/issues/13164

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
