### PR TITLE
fix: simplify mixed schema

### DIFF
--- a/types/FluentJSONSchema.d.ts
+++ b/types/FluentJSONSchema.d.ts
@@ -142,72 +142,10 @@ type InferSchemaMap = {
   null: NullSchema
 }
 
-type MixedSchema1<T> = T extends [infer U]
-  ? InferSchemaMap[U extends TYPE ? U : never]
-  : never
-type MixedSchema2<T> = T extends [infer U, infer V]
-  ? InferSchemaMap[U extends TYPE ? U : never] &
-      InferSchemaMap[V extends TYPE ? V : never]
-  : never
-type MixedSchema3<T> = T extends [infer U, infer V, infer W]
-  ? InferSchemaMap[U extends TYPE ? U : never] &
-      InferSchemaMap[V extends TYPE ? V : never] &
-      InferSchemaMap[W extends TYPE ? W : never]
-  : never
-type MixedSchema4<T> = T extends [infer U, infer V, infer W, infer X]
-  ? InferSchemaMap[U extends TYPE ? U : never] &
-      InferSchemaMap[V extends TYPE ? V : never] &
-      InferSchemaMap[W extends TYPE ? W : never] &
-      InferSchemaMap[X extends TYPE ? X : never]
-  : never
-type MixedSchema5<T> = T extends [infer U, infer V, infer W, infer X, infer Y]
-  ? InferSchemaMap[U extends TYPE ? U : never] &
-      InferSchemaMap[V extends TYPE ? V : never] &
-      InferSchemaMap[W extends TYPE ? W : never] &
-      InferSchemaMap[X extends TYPE ? X : never] &
-      InferSchemaMap[Y extends TYPE ? Y : never]
-  : never
-type MixedSchema6<T> = T extends [
-  infer U,
-  infer V,
-  infer W,
-  infer X,
-  infer Y,
-  infer Z
-]
-  ? InferSchemaMap[U extends TYPE ? U : never] &
-      InferSchemaMap[V extends TYPE ? V : never] &
-      InferSchemaMap[W extends TYPE ? W : never] &
-      InferSchemaMap[X extends TYPE ? X : never] &
-      InferSchemaMap[Y extends TYPE ? Y : never] &
-      InferSchemaMap[Z extends TYPE ? Z : never]
-  : never
-type MixedSchema7<T> = T extends [
-  infer U,
-  infer V,
-  infer W,
-  infer X,
-  infer Y,
-  infer Z,
-  infer A
-]
-  ? InferSchemaMap[U extends TYPE ? U : never] &
-      InferSchemaMap[V extends TYPE ? V : never] &
-      InferSchemaMap[W extends TYPE ? W : never] &
-      InferSchemaMap[X extends TYPE ? X : never] &
-      InferSchemaMap[Y extends TYPE ? Y : never] &
-      InferSchemaMap[Z extends TYPE ? Z : never] &
-      InferSchemaMap[A extends TYPE ? A : never]
-  : never
-
-export type MixedSchema<T> =
-  | MixedSchema1<T>
-  | MixedSchema2<T>
-  | MixedSchema3<T>
-  | MixedSchema4<T>
-  | MixedSchema5<T>
-  | MixedSchema6<T>
-  | MixedSchema7<T>
+export type MixedSchema<T extends TYPE[]> =
+  T extends readonly [infer First extends TYPE, ...infer Rest extends TYPE[]]
+    ? InferSchemaMap[First] & MixedSchema<Rest>
+    : unknown
 
 interface SchemaOptions {
   schema: object
@@ -240,18 +178,7 @@ export interface S extends BaseSchema<S> {
   array: () => ArraySchema
   object: <T extends ObjectPlaceholder = ObjectPlaceholder>() => ObjectSchema<T>
   null: () => NullSchema
-  mixed: <
-    T extends
-      | [TYPE]
-      | [TYPE, TYPE]
-      | [TYPE, TYPE, TYPE]
-      | [TYPE, TYPE, TYPE, TYPE]
-      | [TYPE, TYPE, TYPE, TYPE, TYPE]
-      | [TYPE, TYPE, TYPE, TYPE, TYPE, TYPE]
-      | [TYPE, TYPE, TYPE, TYPE, TYPE, TYPE, TYPE]
-  >(
-    types: T
-  ) => MixedSchema<T>
+  mixed<T extends [TYPE, ...TYPE[]]>(types: T): MixedSchema<T>
   raw: (fragment: any) => S
   FORMATS: FORMATS
 }

--- a/types/FluentJSONSchema.test-d.ts
+++ b/types/FluentJSONSchema.test-d.ts
@@ -86,6 +86,15 @@ const bodySchema = personSchema.without(['createdAt', 'updatedAt'])
 
 console.log('person subset:', JSON.stringify(bodySchema.valueOf()))
 
+const personSchemaAllowsUnix = S.object()
+  .prop('name', S.string())
+  .prop('age', S.number())
+  .prop('id', S.string().format('uuid'))
+  .prop('createdAt', S.mixed(['string', 'integer']).format('time'))
+  .prop('updatedAt', S.mixed(['string', 'integer']).minimum(0))
+
+console.log('person schema allows unix:', JSON.stringify(personSchemaAllowsUnix.valueOf()))
+
 try {
   S.object().prop('foo', 'boom!' as any)
 } catch (e) {


### PR DESCRIPTION
Since type `MixedSchema` seemed that it should be implemented simpler, this PR implements that.

This PR also enables typeof S.mixed to be `<T extends TYPE[]>(types: T) => MixedSchema<T>`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
