### PR TITLE
fix(types): Removes duplicate interface SchemaOptions declaration

### DIFF
--- a/types/FluentJSONSchema.d.ts
+++ b/types/FluentJSONSchema.d.ts
@@ -209,10 +209,6 @@ export type MixedSchema<T> =
   | MixedSchema6<T>
   | MixedSchema7<T>
 
-interface SchemaOptions {
-  schema: object
-  generateIds: boolean
-}
 
 interface PatternPropertiesOptions {
   [key: string]: JSONSchema


### PR DESCRIPTION
Including this library into a Platformatic project led to a compile error reported [here](https://github.com/fastify/help/issues/933)

I see there was a duplicate interface declaration for `SchemaOptions` one exported, one local.

I think it was a mistake so I removed. the local one. With this fix TypeScript compiler is happy.