### PR TITLE
fix: ObjectSchema.extend returns a schema instance

### DIFF
--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -340,14 +340,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
       }
       const src = base._getState()
       const extended = combineDeepmerge(src, schema)
-      const {
-        valueOf,
-        isFluentSchema,
-        FLUENT_SCHEMA,
-        _getState,
-        extend
-      } = ObjectSchema({ schema: extended, ...options })
-      return { valueOf, isFluentSchema, FLUENT_SCHEMA, _getState, extend }
+      return ObjectSchema({ schema: extended, ...options })
     },
 
     /**

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -844,6 +844,25 @@ describe('ObjectSchema', () => {
       })
     })
 
+    it('extends schemas in a chain supporting without after extend', () => {
+      const base = S.object()
+        .prop('foo')
+
+      const extended = S.object()
+        .prop('bar')
+        .prop('baz')
+        .extend(base)
+        .without(['foo'])
+      assert.deepStrictEqual(extended.valueOf(), {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          bar: {},
+          baz: {}
+        }
+      })
+    })
+
     it('throws an error if a schema is not provided', () => {
       assert.throws(
         () => S.object().extend(),
@@ -859,19 +878,6 @@ describe('ObjectSchema', () => {
         (err) =>
           err instanceof S.FluentSchemaError &&
           err.message === "Schema isn't FluentSchema type"
-      )
-    })
-
-    it('throws an error if you append a new prop after extend', () => {
-      assert.throws(
-        () => {
-          const base = S.object()
-          S.object().extend(base).prop('foo')
-        },
-        (err) =>
-          // err instanceof S.FluentSchemaError &&
-          err instanceof TypeError &&
-          err.message === 'S.object(...).extend(...).prop is not a function'
       )
     })
   })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
