### PR TITLE
perf: replace accumulator spread with assignment

### DIFF
--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -139,10 +139,8 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
             "'patternProperties' invalid options. Provide a valid map e.g. { '^fo.*$': S.string() }"
           )
         }
-        return {
-          ...memo,
-          [pattern]: omit(schema.valueOf({ isRoot: false }), ['$schema'])
-        }
+        memo[pattern] = omit(schema.valueOf({ isRoot: false }), ['$schema'])
+        return memo
       }, {})
       return setAttribute({ schema, ...options }, [
         'patternProperties',
@@ -169,12 +167,10 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
             "'dependencies' invalid options. Provide a valid map e.g. { 'foo': ['bar'] } or { 'foo': S.string() }"
           )
         }
-        return {
-          ...memo,
-          [prop]: Array.isArray(schema)
-            ? schema
-            : omit(schema.valueOf({ isRoot: false }), ['$schema', 'type', 'definitions'])
-        }
+        memo[prop] = Array.isArray(schema)
+          ? schema
+          : omit(schema.valueOf({ isRoot: false }), ['$schema', 'type', 'definitions'])
+        return memo
       }, {})
       return setAttribute({ schema, ...options }, [
         'dependencies',
@@ -199,10 +195,8 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
             "'dependentRequired' invalid options. Provide a valid array e.g. { 'foo': ['bar'] }"
           )
         }
-        return {
-          ...memo,
-          [prop]: schema
-        }
+        memo[prop] = schema
+        return memo
       }, {})
 
       return setAttribute({ schema, ...options }, [
@@ -228,10 +222,8 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
           )
         }
 
-        return {
-          ...memo,
-          [prop]: omit(schema.valueOf({ isRoot: false }), ['$schema', 'type', 'definitions'])
-        }
+        memo[prop] = omit(schema.valueOf({ isRoot: false }), ['$schema', 'type', 'definitions'])
+        return memo
       }, {})
 
       return setAttribute({ schema, ...options }, [
@@ -309,12 +301,15 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
       // strip undefined values or empty arrays or internals
       attributes = Object.entries({ ...attributes, $id, type }).reduce(
         (memo, [key, value]) => {
-          return key === '$schema' ||
-            key === 'def' ||
-            value === undefined ||
-            (Array.isArray(value) && value.length === 0 && key !== 'default')
-            ? memo
-            : { ...memo, [key]: value }
+          if (
+            key !== '$schema' &&
+            key !== 'def' &&
+            value !== undefined &&
+            !(Array.isArray(value) && value.length === 0 && key !== 'default')
+          ) {
+            memo[key] = value
+          }
+          return memo
         },
         {}
       )

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 'use strict'
 const deepmerge = require('@fastify/deepmerge')
-const isFluentSchema = (obj) => obj && obj.isFluentSchema
+const isFluentSchema = (obj) => obj?.isFluentSchema
 
 const hasCombiningKeywords = (attributes) =>
   attributes.allOf || attributes.anyOf || attributes.oneOf || attributes.not
@@ -25,20 +25,17 @@ const isBoolean = (value) => typeof value === 'boolean'
 
 const omit = (obj, props) =>
   Object.entries(obj).reduce((memo, [key, value]) => {
-    if (props.includes(key)) return memo
-    return {
-      ...memo,
-      [key]: value
+    if (!props.includes(key)) {
+      memo[key] = value
     }
+    return memo
   }, {})
 
 const flat = (array) =>
   array.reduce((memo, prop) => {
     const { name, ...rest } = prop
-    return {
-      ...memo,
-      [name]: rest
-    }
+    memo[name] = rest
+    return memo
   }, {})
 
 const combineArray = (options) => {
@@ -132,16 +129,14 @@ const patchIdsWithParentId = ({ schema, generateIds, parentId }) => {
     ...schema,
     properties: properties.reduce((memo, [key, props]) => {
       const $id = props.$id || (generateIds ? `#properties/${key}` : undefined)
-      return {
-        ...memo,
-        [key]: {
-          ...props,
-          $id:
-            generateIds && parentId
-              ? `${parentId}/${$id.replace('#', '')}`
-              : $id // e.g. #properties/foo/properties/bar
-        }
+      memo[key] = {
+        ...props,
+        $id:
+          generateIds && parentId
+            ? `${parentId}/${$id.replace('#', '')}`
+            : $id // e.g. #properties/foo/properties/bar
       }
+      return memo
     }, {})
   }
 }
@@ -152,17 +147,14 @@ const appendRequired = ({
 }) => {
   const { schemaRequired, attributeRequired } = (required || []).reduce(
     (memo, item) => {
-      return item === REQUIRED
-        ? {
-            ...memo,
-            // append prop name to the schema.required
-            schemaRequired: [...memo.schemaRequired, name]
-          }
-        : {
-            ...memo,
-            // propagate required attributes
-            attributeRequired: [...memo.attributeRequired, item]
-          }
+      if (item === REQUIRED) {
+        // Append prop name to the schema.required
+        memo.schemaRequired.push(name)
+      } else {
+        // Propagate required attributes
+        memo.attributeRequired.push(item)
+      }
+      return memo
     },
     { schemaRequired: [], attributeRequired: [] }
   )


### PR DESCRIPTION
Stumbled across [this blog post a while ago](https://www.richsnapp.com/article/2019/06-09-reduce-spread-anti-pattern), which covers why using spread (`{...obj}`) syntax in accumulators like `reduce` is a bad idea.

TL;DR: it causes a time complexity of `O(n^2)` instead of `O(n)` because it's creating an increasingly growing new object on every iteration. Whilst with assignment we're mutating the accumulator rather than creating a new object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
