### PR TITLE
types: added missing iso time types

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -311,7 +311,7 @@ The length of a string instance is defined as the number of its characters as de
 <p><a href="https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.6.3.1">reference</a></p>
 </dd>
 <dt><a href="#format">format(format)</a> ⇒ <code><a href="#StringSchema">StringSchema</a></code></dt>
-<dd><p>A string value can be RELATIVE_JSON_POINTER, JSON_POINTER, UUID, REGEX, IPV6, IPV4, HOSTNAME, EMAIL, URL, URI_TEMPLATE, URI_REFERENCE, URI, TIME, DATE,</p>
+<dd><p>A string value can be RELATIVE_JSON_POINTER, JSON_POINTER, UUID, REGEX, IPV6, IPV4, HOSTNAME, EMAIL, URL, URI_TEMPLATE, URI_REFERENCE, URI, TIME, DATE, DATE_TIME, ISO_TIME, ISO_DATE_TIME.</p>
 <p><a href="https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.7.3">reference</a></p>
 </dd>
 <dt><a href="#pattern">pattern(pattern)</a> ⇒ <code><a href="#StringSchema">StringSchema</a></code></dt>
@@ -1200,7 +1200,7 @@ The length of a string instance is defined as the number of its characters as de
 <a name="format"></a>
 
 ## format(format) ⇒ [<code>StringSchema</code>](#StringSchema)
-A string value can be RELATIVE_JSON_POINTER, JSON_POINTER, UUID, REGEX, IPV6, IPV4, HOSTNAME, EMAIL, URL, URI_TEMPLATE, URI_REFERENCE, URI, TIME, DATE,
+A string value can be RELATIVE_JSON_POINTER, JSON_POINTER, UUID, REGEX, IPV6, IPV4, HOSTNAME, EMAIL, URL, URI_TEMPLATE, URI_REFERENCE, URI, TIME, DATE, DATE_TIME, ISO_TIME, ISO_DATE_TIME.
 
 [reference](https://tools.ietf.org/id/draft-handrews-json-schema-validation-01.html#rfc.section.7.3)
 

--- a/src/StringSchema.test.js
+++ b/src/StringSchema.test.js
@@ -101,6 +101,15 @@ describe('StringSchema', () => {
           }
         )
       })
+      it('valid FORMATS.ISO_TIME', () => {
+        assert.deepStrictEqual(
+          StringSchema().format(FORMATS.ISO_TIME).valueOf(),
+          {
+            type: 'string',
+            format: 'iso-time'
+          }
+        )
+      })
       it('invalid', () => {
         assert.throws(
           () => StringSchema().format('invalid'),

--- a/types/FluentJSONSchema.d.ts
+++ b/types/FluentJSONSchema.d.ts
@@ -51,6 +51,8 @@ type FORMATS = {
   TIME: 'time'
   DATE: 'date'
   DATE_TIME: 'date-time'
+  ISO_TIME: 'iso-time'
+  ISO_DATE_TIME: 'iso-date-time'
 }
 
 export type JSONSchema =

--- a/types/FluentJSONSchema.test-d.ts
+++ b/types/FluentJSONSchema.test-d.ts
@@ -197,3 +197,10 @@ const deepTestOnTypes = S.object<ReallyLongType>()
   .valueOf()
 
 console.log('deepTestOnTypes:\n', JSON.stringify(deepTestOnTypes))
+
+const tsIsoSchema = S.object()
+  .prop('createdAt', S.string().format('iso-time'))
+  .prop('updatedAt', S.string().format('iso-date-time'))
+  .valueOf()
+
+console.log('ISO schema OK:', JSON.stringify(tsIsoSchema))


### PR DESCRIPTION
Adding missing TypeScript support for iso-time and iso-date-time formats
Adding documentation for both formats in the API reference
Providing dedicated unit and TypeScript test coverage
fixes: #267 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
