### PR TITLE
fix: Allow setting `type: "object"` when using Boolean JSON Schema combination keywords (`allOf`, `anyOf`, `oneOf`, `not`)

### DIFF
--- a/src/FluentSchema.test.js
+++ b/src/FluentSchema.test.js
@@ -208,6 +208,17 @@ describe('S', () => {
       })
     })
 
+    it('anyOf typed', () => {
+      const schema = S.object()
+        .prop('foo', S.string().anyOf([S.string()]))
+        .valueOf()
+      assert.deepStrictEqual(schema, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        properties: { foo: { type: 'string', anyOf: [{ type: 'string' }] } },
+        type: 'object'
+      })
+    })
+
     it('oneOf', () => {
       const schema = S.object()
         .prop(
@@ -223,6 +234,103 @@ describe('S', () => {
             oneOf: [{ type: 'string' }, { minimum: 10, type: 'number' }]
           },
           notTypeKey: { not: { oneOf: [{ pattern: 'js$', type: 'string' }] } }
+        },
+        type: 'object'
+      })
+    })
+
+    it('oneOf typed', () => {
+      const schema = S.object()
+        .prop(
+          'foo',
+          S.number().oneOf([S.number().maximum(20), S.number().minimum(10)])
+        )
+        .prop('bar', S.string().not(S.oneOf([S.string().pattern('js$')])))
+        .valueOf()
+      assert.deepStrictEqual(schema, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        properties: {
+          foo: {
+            type: 'number',
+            oneOf: [{ maximum: 20, type: 'number' }, { minimum: 10, type: 'number' }]
+          },
+          bar: { type: 'string', not: { oneOf: [{ pattern: 'js$', type: 'string' }] } }
+        },
+        type: 'object'
+      })
+    })
+
+    it('allOf', () => {
+      const schema = S.object()
+        .prop('foo', S.allOf([S.string().pattern('^b'), S.string().minLength(3), S.string().maxLength(3)]))
+        .valueOf()
+      assert.deepStrictEqual(schema, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        properties: {
+          foo: {
+            allOf: [
+              { pattern: '^b', type: 'string' },
+              { minLength: 3, type: 'string' },
+              { maxLength: 3, type: 'string' }
+            ]
+          }
+        },
+        type: 'object'
+      })
+    })
+
+    it('allOf typed', () => {
+      const schema = S.object()
+        .prop('foo', S.string().allOf([S.string().pattern('^b'), S.string().minLength(3), S.string().maxLength(3)]))
+        .valueOf()
+      assert.deepStrictEqual(schema, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        properties: {
+          foo: {
+            type: 'string',
+            allOf: [
+              { pattern: '^b', type: 'string' },
+              { minLength: 3, type: 'string' },
+              { maxLength: 3, type: 'string' }
+            ]
+          }
+        },
+        type: 'object'
+      })
+    })
+
+    it('not', () => {
+      const schema = S.object()
+        .prop('foo', S.not(S.integer().minimum(10)))
+        .valueOf()
+      assert.deepStrictEqual(schema, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        properties: {
+          foo: {
+            not: {
+              type: 'integer',
+              minimum: 10
+            }
+          }
+        },
+        type: 'object'
+      })
+    })
+
+    it('not typed', () => {
+      const schema = S.object()
+        .prop('foo', S.integer().not(S.integer().minimum(10)))
+        .valueOf()
+      assert.deepStrictEqual(schema, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        properties: {
+          foo: {
+            type: 'integer',
+            not: {
+              type: 'integer',
+              minimum: 10
+            }
+          }
         },
         type: 'object'
       })

--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -4,7 +4,6 @@ const {
   omit,
   setAttribute,
   isFluentSchema,
-  hasCombiningKeywords,
   patchIdsWithParentId,
   appendRequired,
   FluentSchemaError,
@@ -294,9 +293,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
         attributes = attributesPatched
       }
 
-      const type = hasCombiningKeywords(attributes)
-        ? undefined
-        : attributes.type
+      const type = attributes.type
 
       // strip undefined values or empty arrays or internals
       attributes = Object.entries({ ...attributes, $id, type }).reduce(

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,9 +2,6 @@
 const deepmerge = require('@fastify/deepmerge')
 const isFluentSchema = (obj) => obj?.isFluentSchema
 
-const hasCombiningKeywords = (attributes) =>
-  attributes.allOf || attributes.anyOf || attributes.oneOf || attributes.not
-
 class FluentSchemaError extends Error {
   constructor (message) {
     super(message)
@@ -219,7 +216,6 @@ const setComposeType = ({ prop, schemas, schema, options }) => {
 
 module.exports = {
   isFluentSchema,
-  hasCombiningKeywords,
   FluentSchemaError,
   last,
   isUniq,

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -6,6 +6,7 @@ const assert = require('node:assert/strict')
 const { setRaw, combineDeepmerge } = require('./utils')
 const { StringSchema } = require('./StringSchema')
 const { ObjectSchema } = require('./ObjectSchema')
+const S = require('./FluentJSONSchema')
 
 describe('setRaw', () => {
   it('add an attribute to a prop using ObjectSchema', () => {
@@ -33,6 +34,41 @@ describe('setRaw', () => {
     assert.deepStrictEqual(schema.valueOf(), {
       nullable: true,
       type: 'string'
+    })
+  })
+
+  it('set type for combination', () => {
+    const factory = ObjectSchema
+    const anyOf = S.anyOf([S.string()]).valueOf()
+    assert.deepStrictEqual(anyOf.valueOf(), {
+      anyOf: [
+        {
+          type: 'string'
+        }
+      ]
+    })
+    const schema = setRaw(
+      {
+        schema: {
+          type: 'object',
+          properties: [{ name: 'foo', ...anyOf }]
+        },
+        factory
+      },
+      { type: 'object' }
+    )
+    assert.deepStrictEqual(schema.valueOf(), {
+      properties: {
+        foo: {
+          type: 'object',
+          anyOf: [
+            {
+              type: 'string'
+            }
+          ]
+        }
+      },
+      type: 'object'
     })
   })
 })


### PR DESCRIPTION
This PR removes `hasCombiningKeywords`, and instead always sets `type` to `attributes.type`. It also adds test cases for the expected behavior.

---

I am using fastify fluent-json-schema for API validation. I noticed an issue where every time the API is started, my logs have multiple warnings related to missing schema properties.

```
strict mode: missing type "object" for keyword "required" at "#/properties/parent" (strictTypes)
strict mode: missing type "object" for keyword "properties" at "#/properties/parent" (strictTypes)
strict mode: missing type "object" for keyword "properties" at "#/properties/parent/allOf/0/if" (strictTypes)
strict mode: missing type "object" for keyword "properties" at "#/properties/parent/allOf/0/then" (strictTypes)
strict mode: missing type "object" for keyword "properties" at "#/properties/parent/allOf/1/if" (strictTypes)
strict mode: missing type "object" for keyword "properties" at "#/properties/parent/allOf/1/then" (strictTypes)
```

These are coming from Ajv, which has the [default option](https://ajv.js.org/options.html#option-defaults) of logging issues that violate [the rules for `strictTypes`](https://ajv.js.org/strict-mode.html#strict-types).

My schema responsible for violating `strictTypes` is like this (see the `allOf inside parent` group in `FluentSchema.integration.test.js`):
```
const schema = S.object()
  .prop('parent', S.object()
    .prop('name', S.string().enum(['foo', 'bar']).required())
    .prop('index', S.number().required())
    .allOf([
      S.ifThen(
        S.object().prop('name', S.const('foo')),
        S.object().prop('index', S.const(0))
      ),
      S.ifThen(
        S.object().prop('name', S.const('bar')),
        S.object().prop('index', S.const(1))
      )
    ])
  ).required()
  .valueOf()
```

I know I can silence these warnings if I pass `{ strictTypes: false }` as Ajv options when initializing fastify, but I wanted to see if I could fix the warning instead of modifying the default options.

I found that the issue is due to the output from fluent-json-schema missing an expected `type: "object"` under the `parent` property.
However, I was unable to get it to show up - `S.object().allOf()`, `S.raw({ schemaWithTypeObject })`, and `S.allOf().raw({ type: "object" })` all were missing the expected `type` field.
```
{
  $schema: 'http://json-schema.org/draft-07/schema#',
  type: 'object',
  properties: {
    parent: {
      type: 'object', // this was always missing
      allOf: [
        ...
      ]
    }
  }
}
```

This behavior happens due to explicitly setting type to `undefined` if there are any combining keywords.

```
const hasCombiningKeywords = (attributes) =>
  attributes.allOf || attributes.anyOf || attributes.oneOf || attributes.not

const type = hasCombiningKeywords(attributes)
  ? undefined
  : attributes.type
```

After looking through the commit history, it seems like this behavior has existed since beginning, aside from being moved around files.

- Nov 13, 2018 (added support for anyOf) https://github.com/fastify/fluent-json-schema/commit/50a357ad98b0c48e59f1f952d287ee1f030d3d0a
- Nov 13, 2018 (extract to hasCombiningKeywords) https://github.com/fastify/fluent-json-schema/commit/c94156eb99952b20588acb524764a232101ad39e
- Nov 13, 2018 (move hasCombiningKeywords utils) https://github.com/fastify/fluent-json-schema/commit/0ab3fb2582e105e8964da6f1ac05fb50691b2a44
- Feb 1, 2019 (removed from FluentSchema) https://github.com/fastify/fluent-json-schema/commit/f6975b13c0719be63cddb7f58d3fbe019c9b978e
- Feb 1, 2019 (initial commit for ObjectSchema, copied from FluentSchema) https://github.com/fastify/fluent-json-schema/commit/88ac13b2e518919541d45cfdc79c7445f4287f8e

I'm not sure what the original reason was for implementing it this way, but I believe that the current behavior should be changed, as combining keywords should be able to specify a type. 

For example, [the docs for json-schema](https://json-schema.org/understanding-json-schema/reference/combining#factoringschemas) have this:
```
{
  "type": "number",
  "oneOf": [
    { "multipleOf": 5 },
    { "multipleOf": 3 }
  ]
}
```

And here are some examples from [Ajv](https://ajv.js.org/strict-mode.html#strict-types):

> This simple JSON Schema is valid, but it violates strictTypes:
> ```
> {
>   properties: {
>     foo: {type: "number"},
>     bar: {type: "string"}
>   }
>   required: ["foo", "bar"]
> }
> ```
> 
> This is a very common mistake that even people experienced with JSON Schema often make - the problem here is that any value that is not an object would be valid against this schema - this is rarely intentional.
> 
> To fix it, "type" keyword has to be added:
> ```
> {
>   type: "object",
>   properties: {
>     foo: {type: "number"},
>     bar: {type: "string"}
>   },
>   required: ["foo", "bar"]
> }
> ```
> You do not necessarily have to have "type" keyword in the same schema object; as long as there is "type" keyword applying to the same part of data instance in the same schema document, not via "$ref", it will be ok:
> ```
> {
>   type: "object",
>   anyOf: [
>     {
>       properties: {foo: {type: "number"}}
>       required: ["foo"]
>     },
>     {
>       properties: {bar: {type: "string"}}
>       required: ["bar"]
>     }
>   ]
> }
> ```
> Both "properties" and "required" need type: "object" to satisfy strictTypes - it is sufficient to have it once in the parent schema, without repeating it in each schema.

After looking into solving this issue, I found #233. It looks like previous attempt to fix it was closed (#237) which used type unions.

This PR is not trying to determine the types of everything inside of a schema combination; instead, it just fixes the current behavior of fluent-json-schema which prevents the creation of a valid schema, even if `S.raw` is used.

As seen in the tests added to `FluentSchema.test.js,` any usage of an operator like `S.allOf()` will remain the same - the only time that type is included is if it is specified like `S.object().allOf()`. This allows the creation of schemas that pass Ajv strict mode, which requires `type: "object"`.

While type is not a requirement for any of these boolean operators, it should still be an option if desired, instead of always being forced to be undefined.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

This PR closes #233