### PR TITLE
chore: remove .husky folder

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx lint-staged


### PR DESCRIPTION
Proposal:

- The `.husky` folder has been removed because it is not in use in this library